### PR TITLE
make robot joint position optional

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -158,6 +158,7 @@ This validates and pushes episodes to the lab-specific HuggingFace repository.
 - Action dict keys not matching `action_space` in the robot profile → validation error at `record_step`.
 - Passing an action chunk instead of per-step actions → validation error.
 - `cartesian_position` in state/action but `orientation_representation` not set → conversion will fail.
+- Joint-space actions require `joint_position` in `robot_state_keys`; Cartesian actions require `cartesian_position`.
 - `robot_state_joint_names` length not matching the `joint_position` array length → HDF5 schema error.
 - Running `uv sync` without `--extra tfds` or `--extra droid` when those features are needed (note: those two extras conflict with each other).
 

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -159,6 +159,7 @@ This validates and pushes episodes to the lab-specific HuggingFace repository.
 - Passing an action chunk instead of per-step actions → validation error.
 - `cartesian_position` in state/action but `orientation_representation` not set → conversion will fail.
 - Joint-space actions require `joint_position` in `robot_state_keys`; Cartesian actions require `cartesian_position`.
+- If `joint_position` is in `robot_state_keys`, `robot_state_joint_names` must be a non-empty list.
 - `robot_state_joint_names` length not matching the `joint_position` array length → HDF5 schema error.
 - Running `uv sync` without `--extra tfds` or `--extra droid` when those features are needed (note: those two extras conflict with each other).
 

--- a/configs/robot_profiles/template.yaml
+++ b/configs/robot_profiles/template.yaml
@@ -59,7 +59,8 @@ orientation_representation: # str
 # ===== Optional Keys =====
 # ==========================
 
-# For knowing what each index in the robot_state["joint_position"] corresponds to
+# Required when "joint_position" is in robot_state_keys.
+# Identifies what each index in robot_state["joint_position"] corresponds to.
 robot_state_joint_names: # list of str
   - # str
 

--- a/configs/robot_profiles/template.yaml
+++ b/configs/robot_profiles/template.yaml
@@ -19,7 +19,9 @@ camera_names: # list of str (Required) (Example: ["left", "right", "wrist"])
 # ===== Observation Related =====
 # ===============================
 
-# Observation keys. Options: "joint_position" (Required), "gripper_position" (Required), "cartesian_position", "base_position"
+# Observation keys. Options: "joint_position", "gripper_position", "cartesian_position", "base_position"
+# "gripper_position" is always required.
+# Joint-space actions require "joint_position"; Cartesian actions require "cartesian_position".
 robot_state_keys: # list of str
   - # str
 
@@ -90,4 +92,4 @@ intrinsic calibration matrix:
 extrinsic calibration matrix:
   <str>: # camera name str
     - # 4 x list of four floats (camera extrinsics in the form of a transformation matrix)
-# ========================  
+# ========================

--- a/oopsie_tools/test/test_robot_setup.py
+++ b/oopsie_tools/test/test_robot_setup.py
@@ -22,8 +22,7 @@ VALID_PROFILE = {
     "gripper_name": "test_gripper",
     "control_freq": 10,
     "camera_names": ["cam0"],
-    "robot_state_keys": ["joint_position", "gripper_position"],
-    "robot_state_joint_names": ["j0", "j1"],
+    "robot_state_keys": ["cartesian_position", "gripper_position"],
     "action_space": ["cartesian_position", "gripper_position"],
 }
 
@@ -96,19 +95,54 @@ class TestRobotProfileMissingRequiredKeys(unittest.TestCase):
 
 
 class TestRobotProfileInvalidRobotStateKeys(unittest.TestCase):
-    def test_missing_joint_position_state_key(self) -> None:
+    def test_cartesian_action_without_cartesian_position_state_key(self) -> None:
         data = {**VALID_PROFILE, "robot_state_keys": ["gripper_position"]}
         with tempfile.TemporaryDirectory() as tmp:
             path = _write_profile(data, tmp)
-            with self.assertRaises(ValueError, msg="missing joint_position in robot_state_keys"):
+            with self.assertRaisesRegex(
+                ValueError,
+                "cartesian_position",
+                msg="Cartesian control without cartesian_position state should raise",
+            ):
                 load_robot_profile(path)
 
     def test_missing_gripper_position_state_key(self) -> None:
-        data = {**VALID_PROFILE, "robot_state_keys": ["joint_position"]}
+        data = {**VALID_PROFILE, "robot_state_keys": ["cartesian_position"]}
         with tempfile.TemporaryDirectory() as tmp:
             path = _write_profile(data, tmp)
             with self.assertRaises(ValueError, msg="missing gripper_position in robot_state_keys"):
                 load_robot_profile(path)
+
+    def test_joint_velocity_action_without_joint_position_state_key(self) -> None:
+        data = {
+            **VALID_PROFILE,
+            "robot_state_keys": ["gripper_position"],
+            "action_space": ["joint_velocity", "gripper_position"],
+            "action_joint_names": ["j0", "j1"],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_profile(data, tmp)
+            with self.assertRaisesRegex(
+                ValueError,
+                "joint_position",
+                msg="Joint velocity control without joint_position state should raise",
+            ):
+                load_robot_profile(path)
+
+    def test_joint_velocity_action_with_joint_position_state_key(self) -> None:
+        data = {
+            **VALID_PROFILE,
+            "robot_state_keys": ["joint_position", "gripper_position"],
+            "robot_state_joint_names": ["j0", "j1"],
+            "action_space": ["joint_velocity", "gripper_position"],
+            "action_joint_names": ["j0", "j1"],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            profile = load_robot_profile(_write_profile(data, tmp))
+            self.assertEqual(
+                profile.robot_state_keys,
+                ["joint_position", "gripper_position"],
+            )
 
     def test_empty_robot_state_keys(self) -> None:
         data = {**VALID_PROFILE, "robot_state_keys": []}
@@ -143,6 +177,8 @@ class TestRobotProfileInvalidActionSpace(unittest.TestCase):
     def test_joint_space_without_joint_names(self) -> None:
         data = {
             **VALID_PROFILE,
+            "robot_state_keys": ["joint_position", "gripper_position"],
+            "robot_state_joint_names": ["j0", "j1"],
             "action_space": ["joint_position", "gripper_position"],
             # action_joint_names intentionally omitted
         }
@@ -154,6 +190,8 @@ class TestRobotProfileInvalidActionSpace(unittest.TestCase):
     def test_joint_velocity_without_joint_names(self) -> None:
         data = {
             **VALID_PROFILE,
+            "robot_state_keys": ["joint_position", "gripper_position"],
+            "robot_state_joint_names": ["j0", "j1"],
             "action_space": ["joint_velocity", "gripper_position"],
         }
         with tempfile.TemporaryDirectory() as tmp:

--- a/oopsie_tools/test/test_robot_setup.py
+++ b/oopsie_tools/test/test_robot_setup.py
@@ -144,6 +144,28 @@ class TestRobotProfileInvalidRobotStateKeys(unittest.TestCase):
                 ["joint_position", "gripper_position"],
             )
 
+    def test_joint_position_state_without_joint_names(self) -> None:
+        for joint_names in (None, []):
+            with self.subTest(robot_state_joint_names=joint_names):
+                data = {
+                    **VALID_PROFILE,
+                    "robot_state_keys": [
+                        "joint_position",
+                        "cartesian_position",
+                        "gripper_position",
+                    ],
+                }
+                if joint_names is not None:
+                    data["robot_state_joint_names"] = joint_names
+
+                with tempfile.TemporaryDirectory() as tmp:
+                    path = _write_profile(data, tmp)
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "robot_state_joint_names is required",
+                    ):
+                        load_robot_profile(path)
+
     def test_empty_robot_state_keys(self) -> None:
         data = {**VALID_PROFILE, "robot_state_keys": []}
         with tempfile.TemporaryDirectory() as tmp:

--- a/oopsie_tools/utils/robot_profile/robot_profile.py
+++ b/oopsie_tools/utils/robot_profile/robot_profile.py
@@ -49,6 +49,13 @@ REQUIRED_ROBOT_STATE_KEYS = frozenset(
     }
 )
 
+ARM_ACTION_REQUIRED_ROBOT_STATE_KEY = {
+    "joint_position": "joint_position",
+    "joint_velocity": "joint_position",
+    "cartesian_position": "cartesian_position",
+    "cartesian_velocity": "cartesian_position",
+}
+
 
 @dataclasses.dataclass(frozen=True)
 class RobotProfile:
@@ -156,14 +163,6 @@ def robot_profile_from_raw(raw: Any) -> RobotProfile:
     if missing:
         raise ValueError(f"Robot profile missing keys: {missing}")
 
-    missing_robot_state_keys = [
-        k for k in REQUIRED_ROBOT_STATE_KEYS if k not in raw.get("robot_state_keys")
-    ]
-    if missing_robot_state_keys:
-        raise ValueError(
-            f"Robot profile missing robot state keys: {missing_robot_state_keys}"
-        )
-
     action_space = list(raw["action_space"])
     if not is_valid_action_space(action_space):
         raise ValueError(
@@ -174,6 +173,20 @@ def robot_profile_from_raw(raw: Any) -> RobotProfile:
             f"{sorted(ACTION_SPACE_SET_2)}, "
             "and optionally 1 base action from "
             f"{sorted(ACTION_SPACE_SET_3)}."
+        )
+
+    required_robot_state_keys = set(REQUIRED_ROBOT_STATE_KEYS)
+    required_robot_state_keys.update(
+        ARM_ACTION_REQUIRED_ROBOT_STATE_KEY[action]
+        for action in action_space
+        if action in ARM_ACTION_REQUIRED_ROBOT_STATE_KEY
+    )
+    robot_state_keys = list(raw["robot_state_keys"])
+    missing_robot_state_keys = sorted(required_robot_state_keys - set(robot_state_keys))
+    if missing_robot_state_keys:
+        raise ValueError(
+            "Robot profile missing robot state keys required by its action_space: "
+            f"{missing_robot_state_keys}"
         )
 
     action_joint_names = _optional_str_list(raw.get("action_joint_names"))
@@ -211,7 +224,7 @@ def robot_profile_from_raw(raw: Any) -> RobotProfile:
         control_freq=raw["control_freq"],
         camera_names=list(raw["camera_names"]),
         # Observation Related
-        robot_state_keys=list(raw["robot_state_keys"]),
+        robot_state_keys=robot_state_keys,
         robot_state_joint_names=list(raw.get("robot_state_joint_names") or []),
         # Action Related
         action_space=action_space,

--- a/oopsie_tools/utils/robot_profile/robot_profile.py
+++ b/oopsie_tools/utils/robot_profile/robot_profile.py
@@ -189,6 +189,15 @@ def robot_profile_from_raw(raw: Any) -> RobotProfile:
             f"{missing_robot_state_keys}"
         )
 
+    robot_state_joint_names = _optional_str_list(
+        raw.get("robot_state_joint_names")
+    )
+    if "joint_position" in robot_state_keys and not robot_state_joint_names:
+        raise ValueError(
+            "robot_state_joint_names is required when joint_position is included "
+            "in robot_state_keys"
+        )
+
     action_joint_names = _optional_str_list(raw.get("action_joint_names"))
     if (
         any(k in {"joint_position", "joint_velocity"} for k in action_space)
@@ -225,7 +234,7 @@ def robot_profile_from_raw(raw: Any) -> RobotProfile:
         camera_names=list(raw["camera_names"]),
         # Observation Related
         robot_state_keys=robot_state_keys,
-        robot_state_joint_names=list(raw.get("robot_state_joint_names") or []),
+        robot_state_joint_names=robot_state_joint_names or [],
         # Action Related
         action_space=action_space,
         action_joint_names=action_joint_names,

--- a/oopsie_tools/utils/robot_profile/robot_profile.py
+++ b/oopsie_tools/utils/robot_profile/robot_profile.py
@@ -45,7 +45,6 @@ REQUIRED_KEYS = frozenset(
 
 REQUIRED_ROBOT_STATE_KEYS = frozenset(
     {
-        "joint_position",
         "gripper_position",
     }
 )
@@ -213,7 +212,7 @@ def robot_profile_from_raw(raw: Any) -> RobotProfile:
         camera_names=list(raw["camera_names"]),
         # Observation Related
         robot_state_keys=list(raw["robot_state_keys"]),
-        robot_state_joint_names=list(raw["robot_state_joint_names"]),
+        robot_state_joint_names=list(raw.get("robot_state_joint_names") or []),
         # Action Related
         action_space=action_space,
         action_joint_names=action_joint_names,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core YAML validation for all robot profiles and episode recording semantics; misconfigured profiles could pass or fail differently than before.
> 
> **Overview**
> **Robot profile validation no longer requires `joint_position` in every profile.** Only `gripper_position` stays mandatory in `robot_state_keys`; arm-related state is inferred from `action_space` (e.g. Cartesian actions require `cartesian_position`, joint position/velocity actions require `joint_position`).
> 
> `robot_profile_from_raw` adds `ARM_ACTION_REQUIRED_ROBOT_STATE_KEY` and fails with a clearer error when required keys are missing. **`robot_state_joint_names` is required whenever `joint_position` appears in state**, and omitted names now normalize to an empty list on the profile object.
> 
> Docs (`AI_CONTEXT.md`, `configs/robot_profiles/template.yaml`) and tests in `test_robot_setup.py` are updated for Cartesian-only minimal profiles and the new joint-name rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ddb967c95325a3720cf67b0315e1fcddc5faa41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->