### PR TITLE
Annotator data visibility & task editing (#30, #31)

### DIFF
--- a/oopsie_tools/annotation_tool/annotation_schema.py
+++ b/oopsie_tools/annotation_tool/annotation_schema.py
@@ -1,0 +1,43 @@
+"""Single definition of how a human annotation is written into an episode HDF5.
+
+Kept in a dependency-light module (json + h5py only) so both the in-the-loop
+recorder patch and the web annotator server can share it without either pulling in
+the other's heavier imports.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import h5py
+
+
+def write_annotation_attrs(group: h5py.Group, annotation: dict[str, Any]) -> None:
+    """Write the oopsie annotation attribute set onto an ``episode_annotations`` subgroup.
+
+    ``binary_success`` maps to the numeric ``success`` attr (1.0/0.0); the failure
+    taxonomy plus the optional qualified-success category live in the ``taxonomy`` JSON.
+    Missing keys fall back to safe defaults, and a ``None`` success (an unrecognized
+    ``binary_success``) is left unwritten rather than crashing h5py.
+    """
+    bs = str(annotation.get("binary_success", "")).strip().lower()
+    success = 1.0 if bs == "success" else 0.0 if bs == "failure" else None
+
+    group.attrs["schema"] = annotation.get("schema", "oopsie_failure_taxonomy_v1")
+    group.attrs["source"] = annotation.get("source", "human")
+    group.attrs["timestamp"] = annotation.get("annotated_at", annotation.get("timestamp", ""))
+    if success is not None:
+        group.attrs["success"] = float(success)
+    group.attrs["failure_description"] = annotation.get("failure_description", "")
+
+    taxonomy: dict[str, Any] = {
+        "failure_category": annotation.get("failure_category", []),
+        "severity": annotation.get("severity", ""),
+    }
+    success_category = str(annotation.get("success_category", "") or "").strip()
+    if success_category:
+        taxonomy["success_category"] = success_category
+    group.attrs["taxonomy_schema"] = "oopsiedata_taxonomy_schema_v1"
+    group.attrs["taxonomy"] = json.dumps(taxonomy, ensure_ascii=False)
+    group.attrs["additional_notes"] = annotation.get("additional_notes", "")

--- a/oopsie_tools/annotation_tool/annotator_server.py
+++ b/oopsie_tools/annotation_tool/annotator_server.py
@@ -34,6 +34,7 @@ import yaml
 from flask import Flask, abort, jsonify, request, send_file
 
 from oopsie_tools.annotation_tool import QUESTIONNAIRE_PATH
+from oopsie_tools.annotation_tool.annotation_schema import write_annotation_attrs
 
 app = Flask(__name__)
 
@@ -414,6 +415,9 @@ def _read_existing_annotation_dict(ea: h5py.Group, annotator_name: str) -> dict[
         sev = tax.get("severity")
         if sev is not None:
             existing_annotation["severity"] = str(sev)
+        sc = tax.get("success_category")
+        if sc is not None:
+            existing_annotation["success_category"] = str(sc)
 
     if not existing_annotation:
         raw_failure = _read_h5_attr(ea, "failure_annotation", "")
@@ -534,6 +538,25 @@ def _summarize_episode_fields(h5f: h5py.File) -> dict[str, Any]:
     return fields
 
 
+def _has_other_human_annotation(h5f: h5py.File, annotator_name: str) -> bool:
+    """Whether a human other than ``annotator_name`` has annotated this episode (#26)."""
+    ea = h5f.get("episode_annotations")
+    if not isinstance(ea, h5py.Group):
+        return False
+    for name in ea.keys():
+        if name == annotator_name:
+            continue
+        sub = ea[name]
+        if not isinstance(sub, h5py.Group):
+            continue
+        source = str(_read_h5_attr(sub, "source", "") or "").strip().lower()
+        if source and source != "human":
+            continue  # VLM / automated annotators don't count as "another annotator"
+        if _annotator_subgroup_looks_annotated(sub):
+            return True
+    return False
+
+
 @app.get("/api/h5/list")
 def api_h5_list():
     rt = _get_runtime()
@@ -544,11 +567,14 @@ def api_h5_list():
             continue
         rel = p.resolve().relative_to(root).as_posix()
         tick_level = 0
+        others = False
         try:
             with h5py.File(p, "r") as h5f:
                 tick_level = _h5_annotation_tick_level(h5f, rt.cfg.annotator_name)
+                others = _has_other_human_annotation(h5f, rt.cfg.annotator_name)
         except Exception:
             tick_level = 0
+            others = False
         annotated = tick_level >= 1
         entries.append(
             {
@@ -558,10 +584,63 @@ def api_h5_list():
                 "mtime": p.stat().st_mtime,
                 "annotated": annotated,
                 "annotation_tick_level": tick_level,
+                "annotated_by_others": others,
             }
         )
     entries.sort(key=lambda e: e.get("rel_path") or "")
     return jsonify(entries)
+
+
+@app.get("/api/annotations/recent")
+def api_recent_annotations():
+    """The current annotator's recent distinct annotations, for the autofill picker (#27)."""
+    rt = _get_runtime()
+    root = rt.cfg.samples_dir.resolve()
+    ann_name = rt.cfg.annotator_name
+    try:
+        limit = int(request.args.get("limit", 15))
+    except (TypeError, ValueError):
+        limit = 15
+    limit = max(1, min(limit, 100))
+
+    files = [p for p in root.rglob("*.h5") if p.is_file()]
+    files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+
+    seen: set[str] = set()
+    recent: list[dict[str, Any]] = []
+    for p in files:
+        if len(recent) >= limit:
+            break
+        try:
+            with h5py.File(p, "r") as h5f:
+                ea = h5f.get("episode_annotations")
+                if not isinstance(ea, h5py.Group):
+                    continue
+                # Only the current annotator's OWN subgroup — never the legacy
+                # episode-level failure_annotation fallback, which isn't
+                # annotator-scoped and could surface someone else's labels (#27).
+                if ann_name not in ea.keys() or not isinstance(ea[ann_name], h5py.Group):
+                    continue
+                ann = _read_existing_annotation_dict(ea, ann_name)
+        except Exception:
+            continue
+        if not ann or not str(ann.get("binary_success", "")).strip():
+            continue
+        key = json.dumps(
+            {
+                "binary_success": str(ann.get("binary_success", "")).strip(),
+                "success_category": str(ann.get("success_category", "")).strip(),
+                "failure_category": sorted(str(x) for x in (ann.get("failure_category") or [])),
+                "severity": str(ann.get("severity", "")).strip(),
+                "failure_description": str(ann.get("failure_description", "")).strip(),
+            },
+            sort_keys=True,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        recent.append(ann)
+    return jsonify(recent)
 
 
 @app.get("/api/h5/sample")
@@ -652,32 +731,11 @@ def api_h5_save_annotation():
 
     ann = rt.save_annotation(sample_id=str(h5_path), payload=payload)
 
-    success: float | None = None
-    bs = str(ann.get("binary_success", "")).strip().lower()
-    if bs == "success":
-        success = 1.0
-    elif bs == "failure":
-        success = 0.0
-
     try:
         with h5py.File(h5_path, "r+") as f:
             ea = f.require_group("episode_annotations")
             ag = ea.require_group(ann["annotator"])
-            ag.attrs["schema"] = ann.get("schema", "oopsie_failure_taxonomy_v1")
-            ag.attrs["source"] = "human"
-            ag.attrs["timestamp"] = ann["annotated_at"]
-            if success is not None:
-                ag.attrs["success"] = float(success)
-            ag.attrs["failure_description"] = ann.get("failure_description", "")
-            ag.attrs["taxonomy_schema"] = "oopsiedata_taxonomy_schema_v1"
-            ag.attrs["taxonomy"] = json.dumps(
-                {
-                    "failure_category": ann.get("failure_category", []),
-                    "severity": ann.get("severity", ""),
-                },
-                ensure_ascii=False,
-            )
-            ag.attrs["additional_notes"] = ann.get("additional_notes", "")
+            write_annotation_attrs(ag, ann)
     except OSError as e:
         return jsonify({"error": f"could not write HDF5: {e}"}), 500
     except Exception as e:

--- a/oopsie_tools/annotation_tool/annotator_server.py
+++ b/oopsie_tools/annotation_tool/annotator_server.py
@@ -477,6 +477,63 @@ def _h5_annotation_tick_level(h5f: h5py.File, annotator_name: str) -> int:
     return 0
 
 
+def _dataset_summary(ds: h5py.Dataset) -> dict[str, Any]:
+    """Shape/dtype summary for a dataset, tolerant of ``h5py.Empty`` (null) datasets."""
+    shape = ds.shape
+    is_tuple = isinstance(shape, tuple)
+    empty = shape is None or (is_tuple and (len(shape) == 0 or 0 in shape))
+    return {
+        "shape": list(shape) if is_tuple else None,
+        "dtype": str(ds.dtype),
+        "empty": bool(empty),
+    }
+
+
+def _summarize_episode_fields(h5f: h5py.File) -> dict[str, Any]:
+    """Compact, read-only summary of everything logged in an episode (issue #30).
+
+    Reads only attrs + dataset shapes/dtypes (no array or video decoding) so the
+    annotator can double-check that all fields were captured correctly.
+    """
+    attr_keys = ("schema", "episode_id", "operator_name", "lab_id", "language_instruction", "timestamp")
+    fields: dict[str, Any] = {
+        "attributes": {k: _read_h5_attr(h5f, k, "") for k in attr_keys},
+        "robot_profile": _parse_taxonomy_json(_read_h5_attr(h5f, "robot_profile", "")),
+        "robot_states": {},
+        "actions": {},
+        "video_paths": {},
+    }
+
+    obs = h5f.get("observations")
+    if isinstance(obs, h5py.Group):
+        rs = obs.get("robot_states")
+        if isinstance(rs, h5py.Group):
+            for key in rs.keys():
+                if isinstance(rs[key], h5py.Dataset):
+                    fields["robot_states"][key] = _dataset_summary(rs[key])
+        vp = obs.get("video_paths")
+        if isinstance(vp, h5py.Group):
+            for cam in vp.keys():
+                try:
+                    fields["video_paths"][cam] = _decode_h5_value(vp[cam][()])
+                except Exception:
+                    continue
+
+    ag = h5f.get("actions")
+    if isinstance(ag, h5py.Group):
+        for key in ag.keys():
+            if isinstance(ag[key], h5py.Dataset):
+                fields["actions"][key] = _dataset_summary(ag[key])
+
+    fields["trajectory_length"] = next(
+        (s["shape"][0] for s in fields["robot_states"].values() if s.get("shape")),
+        None,
+    )
+    ea = h5f.get("episode_annotations")
+    fields["annotators"] = list(ea.keys()) if isinstance(ea, h5py.Group) else []
+    return fields
+
+
 @app.get("/api/h5/list")
 def api_h5_list():
     rt = _get_runtime()
@@ -518,6 +575,7 @@ def api_h5_sample():
 
     video_urls: dict[str, str] = {}
     existing_annotation: dict[str, Any] = {}
+    episode_fields: dict[str, Any] = {}
     metadata: dict[str, Any] = {
         "rel_path": h5_path.resolve().relative_to(samples_root).as_posix()
     }
@@ -528,6 +586,7 @@ def api_h5_sample():
         )
         metadata["episode_id"] = str(_read_h5_attr(h5f, "episode_id", "")) or ""
         metadata["operator_name"] = str(_read_h5_attr(h5f, "operator_name", "")) or ""
+        episode_fields = _summarize_episode_fields(h5f)
 
         ea = h5f.get("episode_annotations")
         if isinstance(ea, h5py.Group):
@@ -573,6 +632,7 @@ def api_h5_sample():
             "metadata": metadata,
             "video_urls": video_urls,
             "existing_annotation": existing_annotation,
+            "episode_fields": episode_fields,
         }
     )
 
@@ -624,6 +684,31 @@ def api_h5_save_annotation():
         return jsonify({"error": f"could not update annotation: {e}"}), 500
 
     return jsonify({"status": "saved", "annotation": ann})
+
+
+@app.post("/api/h5/instruction")
+def api_h5_set_instruction():
+    """Overwrite an episode's ``language_instruction`` root attr (issue #31)."""
+    rt = _get_runtime()
+    samples_root = rt.cfg.samples_dir.resolve()
+    try:
+        h5_path = _safe_h5_path_from_query(samples_root)
+    except H5PathError as e:
+        return jsonify({"error": e.message}), e.status
+
+    instruction = str(_json_payload().get("instruction", "")).strip()
+    if not instruction:
+        return jsonify({"error": "instruction is required"}), 400
+
+    try:
+        with h5py.File(h5_path, "r+") as f:
+            f.attrs["language_instruction"] = instruction
+    except OSError as e:
+        return jsonify({"error": f"could not write HDF5: {e}"}), 500
+    except Exception as e:
+        return jsonify({"error": f"could not update instruction: {e}"}), 500
+
+    return jsonify({"status": "saved", "language_instruction": instruction})
 
 
 TEMPLATE_DIR = Path(__file__).parent / "ui"

--- a/oopsie_tools/annotation_tool/episode_recorder.py
+++ b/oopsie_tools/annotation_tool/episode_recorder.py
@@ -13,6 +13,7 @@ import imageio
 import numpy as np
 import datetime
 import yaml
+from oopsie_tools.annotation_tool.annotation_schema import write_annotation_attrs
 from oopsie_tools.utils.robot_profile.robot_profile import RobotProfile, robot_profile_to_json
 from oopsie_tools.utils.robot_profile.rotation_utils import ActionQuatConversion
 from oopsie_tools.utils.validation.episode_data import EpisodeData, VideoInfo
@@ -679,38 +680,12 @@ class EpisodeRecorder:
         if not h5_path.exists():
             raise FileNotFoundError(str(h5_path))
 
-        success: float | None = None
-        bs = str(annotation.get("binary_success", "")).strip().lower()
-        if bs == "success":
-            success = 1.0
-        elif bs == "failure":
-            success = 0.0
-
         with h5py.File(h5_path, "r+") as f:
             episode_annotations = f.require_group("episode_annotations")
             annotation_group = episode_annotations.require_group(
                 annotation["annotator"]
             )
-            annotation_group.attrs["schema"] = annotation.get("schema", "oopsie_failure_taxonomy_v1")
-            annotation_group.attrs["source"] = "human"
-            annotation_group.attrs["timestamp"] = annotation["annotated_at"]
-            annotation_group.attrs["success"] = success
-            annotation_group.attrs["failure_description"] = annotation[
-                "failure_description"
-            ]
-            annotation_group.attrs["taxonomy_schema"] = "oopsiedata_taxonomy_schema_v1"
-            failure_taxonomy = {
-                "failure_category": annotation["failure_category"],
-                "severity": annotation["severity"],
-            }
-            annotation_group.attrs["taxonomy"] = json.dumps(
-                failure_taxonomy, ensure_ascii=False
-            )
-            annotation_group.attrs["additional_notes"] = annotation["additional_notes"]
-
-            # annotation_group.attrs["failure_annotation"] = json.dumps(
-            #     dict(annotation), ensure_ascii=False
-            # )
+            write_annotation_attrs(annotation_group, annotation)
 
     @property
     def num_steps(self) -> int:

--- a/oopsie_tools/annotation_tool/templates/questionnaire.yaml
+++ b/oopsie_tools/annotation_tool/templates/questionnaire.yaml
@@ -8,15 +8,33 @@ questions:
       - "Success"
       - "Failure"
 
+  - id: success_category
+    type: radio
+    label: "Success quality"
+    required: false
+    show_when:
+      binary_success: ["Success"]
+    options:
+      - name: "Clean success"
+        long_form: "Task completed correctly with no notable side-effects or inefficiencies."
+      - name: "Success with side-effects"
+        long_form: "Task completed, but with unintended side-effects (e.g. knocked over a nearby object, minor collision) that did not prevent completion."
+      - name: "Suboptimal execution"
+        long_form: "Task completed, but inefficiently or awkwardly (e.g. many retries, a very indirect path, near-misses)."
+
   - id: failure_description
     type: textarea
     label: "Describe what went wrong"
     required: false
+    show_when:
+      binary_success: ["Failure"]
 
   - id: failure_category
     type: checkbox
     label: "Failure categories (select all that apply)"
     required: false
+    show_when:
+      binary_success: ["Failure"]
     options:
       - name: "Reaching failure (pre contact)"
         long_form: "Failure to reach the target object or location, resulting in no contact being made. If a grasp just barely misses the object, please count this as a grasp failure rather than a reaching failure."
@@ -37,8 +55,10 @@ questions:
 
   - id: severity
     type: radio
-    label: "How severe is this failure?"
+    label: "Severity (failure impact, or success side-effects)"
     required: false
+    show_when:
+      binary_success: ["Failure", "Success"]
     options:
       - "Low severity - no damage, can be reset and reattempted"
       - "Medium severity - some damage or risk of damage or significant reset required, but can be reattempted"

--- a/oopsie_tools/annotation_tool/ui/annotator.html
+++ b/oopsie_tools/annotation_tool/ui/annotator.html
@@ -267,6 +267,7 @@
       .tree-label { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
 
       .tick { color: #4ade80; font-weight: 800; }
+      .other-mark { color: #a78bfa; font-weight: 800; }
 
       /* Videos: equal sizing */
       /* Videos: vertical stack for larger size */
@@ -344,6 +345,11 @@
       .ef-key { flex: 0 0 42%; color: #94a3b8; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-word; }
       .ef-val { flex: 1; color: #cbd5e1; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-word; }
 
+      /* Autofill from a previous annotation (#27) */
+      #autofillRow { margin-bottom: 16px; }
+      .autofill-label { display: block; font-size: 0.8rem; color: #94a3b8; font-weight: 500; }
+      .autofill-label select { margin-top: 4px; }
+
       /* Editable task instruction (#31) */
       .link-btn { background: none; border: none; color: #60a5fa; font-size: 0.7rem; padding: 0 0 0 6px; font-weight: 600; cursor: pointer; }
       .link-btn:hover { background: none; text-decoration: underline; }
@@ -406,6 +412,7 @@
           <div class="h5-legend" aria-label="Annotation status icons">
             <div class="h5-legend-row"><span class="tick">✓</span> Only Success/failure Annotated (failure details incomplete).</div>
             <div class="h5-legend-row"><span class="tick">✓✓</span> Complete: Success/failure Annotated with description, category, and severity.</div>
+            <div class="h5-legend-row"><span class="other-mark">◆</span> Also annotated by another annotator.</div>
           </div>
           <input id="h5Search" class="h5-search" type="text" placeholder="Search…" />
           <div class="h5-nav">
@@ -463,6 +470,11 @@
             </div>
             <div id="metadataPanel" style="display:none;"></div>
             <div id="episodeFields" style="display:none;"></div>
+            <div id="autofillRow" style="display:none;">
+              <label class="autofill-label">Copy from a previous annotation
+                <select id="autofillSelect"><option value="">— select —</option></select>
+              </label>
+            </div>
             <div id="questionnaire"></div>
           </div>
           <div class="save-bar" id="saveBar">
@@ -569,9 +581,12 @@
         if (which === "annotateCard") {
           el("questionnaire").style.display = "";
           el("saveBar").style.display = "";
+          el("autofillRow").style.display =
+            (window.__recentAnnotations && window.__recentAnnotations.length) ? "" : "none";
         } else {
           el("metadataPanel").style.display = "none";
           el("episodeFields").style.display = "none";
+          el("autofillRow").style.display = "none";
           el("questionnaire").style.display = "none";
           el("saveBar").style.display = "none";
         }
@@ -752,6 +767,40 @@
             ${section("Other", kvRows({ trajectory_length: fields.trajectory_length, annotators: (fields.annotators || []).join(", ") }))}
           </details>`;
         panel.style.display = "";
+      }
+
+      // ── Autofill from a previous annotation (#27) ──────────────────────────
+      async function loadRecentAnnotations() {
+        try {
+          const items = await jget("/api/annotations/recent?limit=15");
+          window.__recentAnnotations = Array.isArray(items) ? items : [];
+        } catch (e) {
+          window.__recentAnnotations = [];
+        }
+        renderAutofillOptions();
+      }
+      function annotationSummaryLabel(a) {
+        const bs = String(a?.binary_success || "").trim() || "?";
+        if (bs === "Failure") {
+          const cats = (a.failure_category || []).join(", ");
+          const desc = String(a.failure_description || "").trim();
+          return `Failure — ${cats || "(no category)"}${desc ? ": " + desc.slice(0, 60) : ""}`;
+        }
+        const sc = String(a?.success_category || "").trim();
+        return `Success${sc ? " — " + sc : ""}`;
+      }
+      function renderAutofillOptions() {
+        const sel = el("autofillSelect");
+        const row = el("autofillRow");
+        if (!sel || !row) return;
+        const items = window.__recentAnnotations || [];
+        sel.innerHTML = items.length
+          ? '<option value="">— copy from a previous annotation —</option>' +
+            items.map((a, i) => `<option value="${i}">${escHtml(annotationSummaryLabel(a))}</option>`).join("")
+          : '<option value="">— select —</option>';
+        // Only surface the picker while annotating; showOnly also manages this.
+        const annotating = el("annotateCard").style.display !== "none";
+        row.style.display = (items.length && annotating) ? "" : "none";
       }
 
       function inputForQuestion(q) {
@@ -948,8 +997,14 @@
       }
 
       function validateSaveAnswers(answers) {
-        if (!String(answers?.binary_success ?? "").trim()) {
+        const bs = String(answers?.binary_success ?? "").trim();
+        if (!bs) {
           return "Please annotate success/failure.";
+        }
+        // The failure taxonomy trio is all-or-nothing, but only for failures — a
+        // (qualified) success may set severity/notes independently (#29).
+        if (bs !== "Failure") {
+          return "";
         }
         const categoryFilled =
           Array.isArray(answers?.failure_category) && answers.failure_category.length > 0;
@@ -962,16 +1017,31 @@
         return "";
       }
 
-      const FAILURE_ONLY_QUESTIONS = ["failure_category", "failure_description", "severity"];
+      function questionCurrentValue(id) {
+        const checked = document.querySelector(`input[type="radio"][name="${CSS.escape(id)}"]:checked`);
+        if (checked) return checked.value;
+        const other = document.querySelector(`[name="${CSS.escape(id)}"]`);
+        return other ? String(other.value ?? "") : "";
+      }
 
+      // Data-driven conditional visibility (#29): a question with
+      // `show_when: {binary_success: [...]}` is shown only when every referenced
+      // question currently holds one of the listed values. Questions without a
+      // `show_when` are always visible. Generalizes the old hard-coded failure hide.
       function applySuccessConditional() {
-        const selected = document.querySelector('input[type="radio"][name="binary_success"]:checked');
-        const isSuccess = selected && selected.value === "Success";
-        FAILURE_ONLY_QUESTIONS.forEach((id) => {
+        const qs = Array.isArray(window.__questionnaireSpec?.questions) ? window.__questionnaireSpec.questions : [];
+        for (const q of qs) {
+          const id = q.id || q.name || q.key;
+          const cond = q && q.show_when;
+          if (!id || !cond || typeof cond !== "object") continue;
           const group = document.querySelector(`[data-question-id="${CSS.escape(id)}"]`);
-          if (!group) return;
-          group.style.display = isSuccess ? "none" : "";
-        });
+          if (!group) continue;
+          const visible = Object.entries(cond).every(([depId, allowed]) => {
+            const vals = Array.isArray(allowed) ? allowed.map(String) : [String(allowed)];
+            return vals.includes(questionCurrentValue(depId));
+          });
+          group.style.display = visible ? "" : "none";
+        }
       }
 
       let currentSampleId = null; // rollout sample_id
@@ -1072,7 +1142,7 @@
           const items = await jget("/api/h5/list");
           const arr = Array.isArray(items) ? items : [];
           // Lightweight signature: rel_path + annotated + mtime.
-          const sig = arr.map(it => `${it.rel_path}|${Number(it.annotation_tick_level ?? 0)}|${it.mtime}`).join("\n");
+          const sig = arr.map(it => `${it.rel_path}|${Number(it.annotation_tick_level ?? 0)}|${it.annotated_by_others ? 1 : 0}|${it.mtime}`).join("\n");
           if (sig !== lastH5ListSig) {
             lastH5ListSig = sig;
             window.__h5Items = arr;
@@ -1155,11 +1225,14 @@
             const active = (browseRelPath === rp) ? "active" : "";
             const tl = Number(it.annotation_tick_level ?? 0);
             const tick = tl >= 2 ? "✓✓ " : tl >= 1 ? "✓ " : "";
+            const other = it.annotated_by_others
+              ? '<span class="other-mark" title="Also annotated by another annotator">◆</span> '
+              : "";
             const indent = depth * 14;
             lines.push(
               `<div class="tree-row ${active}" data-kind="file" data-rel="${esc(rp)}" style="margin-left:${indent}px;">` +
               `<span class="tree-arrow"></span>` +
-              `<span class="tree-label">${tick}${esc(it._fileName)}</span>` +
+              `<span class="tree-label">${other}${tick}${esc(it._fileName)}</span>` +
               `</div>`
             );
           }
@@ -1203,6 +1276,20 @@
         const ann = existing && typeof existing === "object" ? existing : {};
         const skip = new Set(["annotated_at", "annotator", "source"]);
         const qs = Array.isArray(window.__questionnaireSpec?.questions) ? window.__questionnaireSpec.questions : [];
+        // Reset every managed field first so applying a (possibly partial) annotation —
+        // e.g. copying a previous annotation onto an already-filled form (#27) — never
+        // leaves stale values (like a success_category) from a prior selection.
+        for (const q of qs) {
+          const id = q.id || q.name || q.key;
+          if (!id || skip.has(id)) continue;
+          const type = String(q.type || "text").toLowerCase();
+          if (type === "checkbox" || type === "radio") {
+            document.querySelectorAll(`input[name="${CSS.escape(id)}"]`).forEach((e) => { e.checked = false; });
+          } else {
+            const el0 = document.querySelector(`[name="${CSS.escape(id)}"]`);
+            if (el0) el0.value = "";
+          }
+        }
         for (const q of qs) {
           const id = q.id || q.name || q.key;
           if (!id || skip.has(id)) continue;
@@ -1420,6 +1507,7 @@
           el("saveMsg").textContent = "";
           markSaved();
           await pollH5List();
+          loadRecentAnnotations().catch(() => {}); // the just-saved annotation becomes copyable
           if (browseRelPath && autoAdvanceEnabled()) {
             await navigateBy(1);
           }
@@ -1446,6 +1534,18 @@
         el("instrEditInput").focus();
       });
       el("instrCancelBtn").addEventListener("click", () => { el("instrEditRow").style.display = "none"; });
+
+      // Autofill: copy a chosen previous annotation into the form (#27)
+      el("autofillSelect").addEventListener("change", () => {
+        const items = window.__recentAnnotations || [];
+        const idx = parseInt(el("autofillSelect").value, 10);
+        if (Number.isInteger(idx) && items[idx]) {
+          populateForm(items[idx]);
+          setDirty(true);
+          el("saveMsg").textContent = "Copied from a previous annotation — review and Save.";
+        }
+        el("autofillSelect").value = "";
+      });
       el("instrSaveBtn").addEventListener("click", async () => {
         if (!browseRelPath) return;
         const val = el("instrEditInput").value.trim();
@@ -1554,6 +1654,7 @@
       }
 
       loadH5List().catch(() => {});
+      loadRecentAnnotations().catch(() => {});
       if (typeof ANNOTATOR_BROWSE_ONLY === "undefined" || !ANNOTATOR_BROWSE_ONLY) {
         setInterval(() => refresh().catch(() => {}), 800);
         setInterval(() => pollH5List().catch(() => {}), 1500);

--- a/oopsie_tools/annotation_tool/ui/annotator.html
+++ b/oopsie_tools/annotation_tool/ui/annotator.html
@@ -334,6 +334,23 @@
       .meta-key { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.5px; color: #64748b; }
       .meta-val { font-size: 0.8rem; color: #cbd5e1; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-all; }
 
+      /* Episode data visualizer (#30) */
+      #episodeFields { margin-bottom: 16px; }
+      .episode-data { background: #0f172a; border: 1px solid #334155; border-radius: 6px; padding: 8px 12px; font-size: 0.8rem; }
+      .episode-data summary { cursor: pointer; color: #94a3b8; font-weight: 600; }
+      .ef-section { margin-top: 10px; }
+      .ef-section-title { font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.5px; color: #64748b; margin-bottom: 3px; }
+      .ef-row { display: flex; gap: 10px; padding: 1px 0; }
+      .ef-key { flex: 0 0 42%; color: #94a3b8; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-word; }
+      .ef-val { flex: 1; color: #cbd5e1; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-word; }
+
+      /* Editable task instruction (#31) */
+      .link-btn { background: none; border: none; color: #60a5fa; font-size: 0.7rem; padding: 0 0 0 6px; font-weight: 600; cursor: pointer; }
+      .link-btn:hover { background: none; text-decoration: underline; }
+      #instrEditRow input { margin-bottom: 6px; }
+      #instrEditRow .instr-btns { display: flex; gap: 6px; }
+      #instrEditRow .instr-btns button { padding: 6px 10px; font-size: 0.85rem; }
+
       /* Questionnaire container */
       #questionnaire h3 { margin-bottom: 12px; }
 
@@ -434,10 +451,18 @@
         <div class="form-section">
           <div class="form-scroll">
             <div class="task-instruction-box">
-              <div class="task-instruction-box-label">Task instruction</div>
+              <div class="task-instruction-box-label">Task instruction<button id="editInstrBtn" class="link-btn" type="button" style="display:none;" title="Edit this episode's task instruction">edit</button></div>
               <div class="task-instruction-box-value" id="sessionTaskInstruction">—</div>
+              <div id="instrEditRow" style="display:none; margin-top:8px;">
+                <input id="instrEditInput" type="text" placeholder="Task instruction" />
+                <div class="instr-btns">
+                  <button id="instrSaveBtn" class="primary" type="button">Save instruction</button>
+                  <button id="instrCancelBtn" type="button">Cancel</button>
+                </div>
+              </div>
             </div>
             <div id="metadataPanel" style="display:none;"></div>
+            <div id="episodeFields" style="display:none;"></div>
             <div id="questionnaire"></div>
           </div>
           <div class="save-bar" id="saveBar">
@@ -511,6 +536,10 @@
           fileEl.title = fileTitle;
         }
         if (taskEl) taskEl.textContent = task;
+        // The task instruction is only editable for a selected HDF5 episode (#31).
+        const editBtn = el("editInstrBtn");
+        if (editBtn) editBtn.style.display = browseRelPath ? "" : "none";
+        if (!browseRelPath) el("instrEditRow").style.display = "none";
       }
 
       async function jget(url) {
@@ -542,6 +571,7 @@
           el("saveBar").style.display = "";
         } else {
           el("metadataPanel").style.display = "none";
+          el("episodeFields").style.display = "none";
           el("questionnaire").style.display = "none";
           el("saveBar").style.display = "none";
         }
@@ -676,6 +706,51 @@
               ${extraRows.map(r => `<div class="meta-item"><span class="meta-key">${r.k}</span><span class="meta-val">${r.v}</span></div>`).join("")}
             </div>
           </div>`;
+        panel.style.display = "";
+      }
+
+      // ── Episode data visualizer (#30) ──────────────────────────────────────
+      function escHtml(s) {
+        return String(s ?? "")
+          .replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+      }
+      function fmtFieldVal(v) {
+        if (v == null) return "";
+        if (Array.isArray(v)) return v.map(fmtFieldVal).join(", ");
+        if (typeof v === "object") return JSON.stringify(v);
+        return String(v);
+      }
+      function renderEpisodeFields(fields) {
+        const panel = el("episodeFields");
+        if (!panel) return;
+        if (!fields || typeof fields !== "object" || !Object.keys(fields).length) {
+          panel.style.display = "none";
+          panel.innerHTML = "";
+          return;
+        }
+        const kvRows = (obj) => Object.entries(obj || {})
+          .map(([k, v]) => `<div class="ef-row"><span class="ef-key">${escHtml(k)}</span><span class="ef-val">${escHtml(fmtFieldVal(v))}</span></div>`)
+          .join("");
+        const dsRows = (obj) => Object.entries(obj || {})
+          .map(([k, v]) => {
+            const shape = Array.isArray(v && v.shape) ? `[${v.shape.join(", ")}]` : "scalar";
+            const empty = v && v.empty ? "  (empty)" : "";
+            return `<div class="ef-row"><span class="ef-key">${escHtml(k)}</span><span class="ef-val">${escHtml(shape)} · ${escHtml(String((v && v.dtype) || ""))}${escHtml(empty)}</span></div>`;
+          }).join("");
+        const section = (title, body) => body ? `<div class="ef-section"><div class="ef-section-title">${escHtml(title)}</div>${body}</div>` : "";
+        const nStates = Object.keys(fields.robot_states || {}).length;
+        const nActions = Object.values(fields.actions || {}).filter((a) => a && !a.empty).length;
+        panel.innerHTML = `
+          <details class="episode-data">
+            <summary>Episode data — ${nStates} state · ${nActions} action key(s)</summary>
+            ${section("Attributes", kvRows(fields.attributes))}
+            ${section("Robot profile", kvRows(fields.robot_profile))}
+            ${section("observations/robot_states (shape · dtype)", dsRows(fields.robot_states))}
+            ${section("actions (shape · dtype)", dsRows(fields.actions))}
+            ${section("observations/video_paths", kvRows(fields.video_paths))}
+            ${section("Other", kvRows({ trajectory_length: fields.trajectory_length, annotators: (fields.annotators || []).join(", ") }))}
+          </details>`;
         panel.style.display = "";
       }
 
@@ -1157,6 +1232,7 @@
         currentBrowseSample = null;
         questionnaireRenderedFor = null;
         videosRenderedFor = null;
+        el("instrEditRow").style.display = "none"; // never carry an open edit onto another episode (#31)
         renderH5List();
         await refresh();
         prefetchNeighbors(relPath).catch(() => {});
@@ -1166,6 +1242,7 @@
         browseRelPath = null;
         currentBrowseSample = null;
         el("saveMsg").textContent = "";
+        el("instrEditRow").style.display = "none";
         questionnaireRenderedFor = null;
         videosRenderedFor = null;
         renderH5List();
@@ -1193,6 +1270,7 @@
 
             if (videosRenderedFor !== browseRelPath) {
               renderVideos(currentBrowseSample?.video_urls || {});
+              renderEpisodeFields(currentBrowseSample?.episode_fields || null);
               videosRenderedFor = browseRelPath;
             }
             if (questionnaireRenderedFor !== browseRelPath) {
@@ -1208,6 +1286,7 @@
           showOnly("annotateCard");
           if (videosRenderedFor !== "__browse_landing__") {
             renderVideos({});
+            renderEpisodeFields(null);
             videosRenderedFor = "__browse_landing__";
           }
           if (questionnaireRenderedFor !== "__browse_landing__") {
@@ -1233,6 +1312,7 @@
 
           if (videosRenderedFor !== browseRelPath) {
             renderVideos(currentBrowseSample?.video_urls || {});
+            renderEpisodeFields(currentBrowseSample?.episode_fields || null);
             videosRenderedFor = browseRelPath;
           }
           if (questionnaireRenderedFor !== browseRelPath) {
@@ -1273,6 +1353,7 @@
           // Render videos only when the sample changes.
           if (nextSampleId && videosRenderedFor !== nextSampleId) {
             renderVideos(cs.video_urls || {});
+            renderEpisodeFields(null);
             videosRenderedFor = nextSampleId;
           }
 
@@ -1356,6 +1437,39 @@
       el("prevBtn").addEventListener("click", () => navigateBy(-1));
       el("nextBtn").addEventListener("click", () => navigateBy(1));
 
+      // Editable task instruction (#31)
+      el("editInstrBtn").addEventListener("click", () => {
+        if (!browseRelPath) return;
+        const cur = String(currentBrowseSample?.metadata?.language_instruction || "").trim();
+        el("instrEditInput").value = cur;
+        el("instrEditRow").style.display = "";
+        el("instrEditInput").focus();
+      });
+      el("instrCancelBtn").addEventListener("click", () => { el("instrEditRow").style.display = "none"; });
+      el("instrSaveBtn").addEventListener("click", async () => {
+        if (!browseRelPath) return;
+        const val = el("instrEditInput").value.trim();
+        if (!val) { alert("Instruction cannot be empty."); return; }
+        el("instrSaveBtn").disabled = true;
+        try {
+          await jpost(`/api/h5/instruction?path=${encodeURIComponent(browseRelPath)}`, { instruction: val });
+          if (currentBrowseSample && currentBrowseSample.metadata) {
+            currentBrowseSample.metadata.language_instruction = val;
+          }
+          if (currentBrowseSample && currentBrowseSample.episode_fields && currentBrowseSample.episode_fields.attributes) {
+            currentBrowseSample.episode_fields.attributes.language_instruction = val;
+            renderEpisodeFields(currentBrowseSample.episode_fields); // keep the data panel in sync
+          }
+          el("sessionTaskInstruction").textContent = val;
+          sampleCache.delete(browseRelPath); // cached sample now has a stale instruction
+          el("instrEditRow").style.display = "none";
+        } catch (e) {
+          alert(String(e));
+        } finally {
+          el("instrSaveBtn").disabled = false;
+        }
+      });
+
       // Dirty tracking: any real edit flips the indicator and clears stale messages (#34).
       el("questionnaire").addEventListener("input", () => { setDirty(true); el("saveMsg").textContent = ""; });
       el("questionnaire").addEventListener("change", () => { setDirty(true); el("saveMsg").textContent = ""; });
@@ -1392,6 +1506,19 @@
       // are ignored while typing in a field.
       document.addEventListener("keydown", (e) => {
         const t = e.target;
+        // The instruction editor owns Enter=save / Esc=cancel / Ctrl+S=save (#31), so its
+        // keys never fall through to the questionnaire save hotkey (which would save the
+        // annotation and auto-advance, silently discarding the typed instruction).
+        if (t === el("instrEditInput")) {
+          if (e.key === "Enter" || ((e.ctrlKey || e.metaKey) && (e.key === "s" || e.key === "S"))) {
+            e.preventDefault();
+            el("instrSaveBtn").click();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            el("instrCancelBtn").click();
+          }
+          return;
+        }
         const typing = t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.tagName === "SELECT" || t.isContentEditable);
         if ((e.ctrlKey || e.metaKey) && (e.key === "s" || e.key === "S" || e.key === "Enter")) {
           e.preventDefault();

--- a/oopsie_tools/test/test_annotator_server.py
+++ b/oopsie_tools/test/test_annotator_server.py
@@ -65,3 +65,42 @@ def test_video_urls_resolved_for_flat_layout(client, tmp_path: Path) -> None:
     data = _get_sample(client, "flat.h5")
 
     assert "front" in data["video_urls"]
+
+
+def test_sample_returns_episode_fields(client, tmp_path: Path) -> None:
+    """/api/h5/sample summarizes all logged fields for the visualizer (#30)."""
+    write_valid_episode(tmp_path, stem="ep")
+
+    fields = _get_sample(client, "ep.h5")["episode_fields"]
+
+    assert fields["attributes"]["lab_id"] == "test_lab"
+    assert fields["robot_profile"]["policy_name"] == "test_policy"
+    assert fields["robot_states"]["joint_position"]["shape"] == [20, 7]
+    assert fields["robot_states"]["joint_position"]["empty"] is False
+    # Unused action keys are stored as h5py.Empty and flagged empty.
+    assert fields["actions"]["joint_velocity"]["empty"] is False
+    assert fields["actions"]["cartesian_position"]["empty"] is True
+    assert fields["trajectory_length"] == 20
+
+
+def test_set_instruction_persists(client, tmp_path: Path) -> None:
+    """POST /api/h5/instruction overwrites the language_instruction attr (#31)."""
+    write_valid_episode(tmp_path, stem="ep")
+
+    resp = client.post(
+        "/api/h5/instruction?path=ep.h5",
+        json={"instruction": "pour the water carefully"},
+    )
+    assert resp.status_code == 200, resp.data
+
+    data = _get_sample(client, "ep.h5")
+    assert data["metadata"]["language_instruction"] == "pour the water carefully"
+    assert data["episode_fields"]["attributes"]["language_instruction"] == "pour the water carefully"
+
+
+def test_set_instruction_rejects_empty(client, tmp_path: Path) -> None:
+    write_valid_episode(tmp_path, stem="ep")
+
+    resp = client.post("/api/h5/instruction?path=ep.h5", json={"instruction": "  "})
+
+    assert resp.status_code == 400

--- a/oopsie_tools/test/test_annotator_server.py
+++ b/oopsie_tools/test/test_annotator_server.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import h5py
 import pytest
 
+from oopsie_tools.annotation_tool.annotation_schema import write_annotation_attrs
 from oopsie_tools.annotation_tool.annotator_server import app, configure_runtime
 from oopsie_tools.test.fixtures.make_valid import (
     _write_base_h5,
@@ -104,3 +105,80 @@ def test_set_instruction_rejects_empty(client, tmp_path: Path) -> None:
     resp = client.post("/api/h5/instruction?path=ep.h5", json={"instruction": "  "})
 
     assert resp.status_code == 400
+
+
+def test_save_success_category_roundtrip(client, tmp_path: Path) -> None:
+    """A qualified success stores success_category in the taxonomy and reads back (#29)."""
+    write_valid_episode(tmp_path, stem="ep")
+
+    resp = client.post(
+        "/api/h5/annotations?path=ep.h5",
+        json={
+            "binary_success": "Success",
+            "success_category": "Success with side-effects",
+            "severity": "Low severity - no damage, can be reset and reattempted",
+            "failure_category": [],
+            "failure_description": "",
+            "additional_notes": "clipped a nearby cup",
+        },
+    )
+    assert resp.status_code == 200, resp.data
+
+    data = _get_sample(client, "ep.h5")
+    assert data["metadata"]["success"] == 1.0
+    ann = data["existing_annotation"]
+    assert ann["binary_success"] == "Success"
+    assert ann["success_category"] == "Success with side-effects"
+    assert ann["severity"].startswith("Low severity")
+
+
+def test_recent_annotations_returns_distinct(client, tmp_path: Path) -> None:
+    """/api/annotations/recent surfaces the annotator's distinct prior labels (#27)."""
+    write_valid_episode(tmp_path, stem="a")  # success by test_annotator
+    write_valid_episode(tmp_path, stem="b")
+    client.post(
+        "/api/h5/annotations?path=b.h5",
+        json={
+            "binary_success": "Failure",
+            "failure_category": ["Other"],
+            "failure_description": "dropped the object",
+            "severity": "Low severity - no damage, can be reset and reattempted",
+        },
+    )
+
+    items = client.get("/api/annotations/recent?limit=10").get_json()
+    kinds = {i["binary_success"] for i in items}
+
+    assert "Success" in kinds and "Failure" in kinds
+
+
+def test_list_reports_other_human_annotator(client, tmp_path: Path) -> None:
+    """api_h5_list flags episodes annotated by a different human (#26)."""
+    write_valid_episode(tmp_path, stem="ep")  # annotated by test_annotator
+    with h5py.File(tmp_path / "ep.h5", "r+") as f:
+        g = f["episode_annotations"].require_group("someone_else")
+        write_annotation_attrs(
+            g,
+            {
+                "binary_success": "Failure",
+                "source": "human",
+                "failure_category": ["Other"],
+                "failure_description": "x",
+                "severity": "Low severity - no damage, can be reset and reattempted",
+            },
+        )
+
+    entry = next(e for e in client.get("/api/h5/list").get_json() if e["rel_path"] == "ep.h5")
+    assert entry["annotated_by_others"] is True
+
+
+def test_list_ignores_nonhuman_annotator(client, tmp_path: Path) -> None:
+    """VLM/automated subgroups do not count as 'another annotator' (#26)."""
+    write_valid_episode(tmp_path, stem="ep")
+    with h5py.File(tmp_path / "ep.h5", "r+") as f:
+        g = f["episode_annotations"].require_group("cosmos-7b")
+        g.attrs["source"] = "cosmos-7b"
+        g.attrs["success"] = 0.0
+
+    entry = next(e for e in client.get("/api/h5/list").get_json() if e["rel_path"] == "ep.h5")
+    assert entry["annotated_by_others"] is False

--- a/oopsie_tools/test/test_validate.py
+++ b/oopsie_tools/test/test_validate.py
@@ -17,9 +17,11 @@ TestValidateSessionDir    – directory-level validation
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
+import h5py
 import pytest
 
 _VALIDATE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "validate_and_upload"
@@ -151,7 +153,7 @@ class TestTrajectoryLengths:
     def test_zero_trajectory_via_tmp_path(self, tmp_path):
         h5_path = write_valid_episode(tmp_path, "zero", n=0)
         with pytest.raises(AssertionError):
-            validate_h5_file(str(h5_path))
+            validate_h5_file(str(h5_path), strict_annotation_check=True)
 
 
 # ---------------------------------------------------------------------------
@@ -248,3 +250,56 @@ class TestValidateSessionDir:
         write_valid_episode(tmp_path, "ep_a")
         write_valid_episode(tmp_path, "ep_b")
         assert validate_session_dir(str(tmp_path)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Annotation semantics (#29 qualified success, #26 multi/non-human annotators)
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationSemantics:
+    def test_success_with_standalone_severity_passes(self, tmp_path: Path) -> None:
+        """A qualified success may set severity without the failure trio (#29)."""
+        h5_path = write_valid_episode(tmp_path, stem="ep")
+        with h5py.File(h5_path, "r+") as f:
+            g = f["episode_annotations"]["test_annotator"]
+            g.attrs["success"] = 1.0
+            g.attrs["taxonomy"] = json.dumps(
+                {
+                    "failure_category": [],
+                    "severity": "Low severity - no damage, can be reset and reattempted",
+                    "success_category": "Success with side-effects",
+                }
+            )
+        assert validate_h5_file(str(h5_path), strict_annotation_check=True) is True
+
+    def test_failure_still_requires_full_trio(self, tmp_path: Path) -> None:
+        """A failure with only severity (partial trio) is still rejected."""
+        h5_path = write_valid_episode(tmp_path, stem="ep")
+        with h5py.File(h5_path, "r+") as f:
+            g = f["episode_annotations"]["test_annotator"]
+            g.attrs["success"] = 0.0
+            g.attrs["failure_description"] = ""
+            g.attrs["taxonomy"] = json.dumps(
+                {"failure_category": [], "severity": "Low severity - no damage, can be reset and reattempted"}
+            )
+        with pytest.raises(AssertionError, match="all filled or all empty"):
+            validate_h5_file(str(h5_path), strict_annotation_check=True)
+
+    def test_incomplete_extra_subgroup_fails(self, tmp_path: Path) -> None:
+        """Every annotator subgroup must be complete: a stray incomplete one fails the episode."""
+        h5_path = write_valid_episode(tmp_path, stem="ep")
+        with h5py.File(h5_path, "r+") as f:
+            extra = f["episode_annotations"].require_group("cosmos-7b")
+            extra.attrs["source"] = "cosmos-7b"  # no 'success' → incomplete subgroup
+        with pytest.raises(AssertionError, match="missing 'success'"):
+            validate_h5_file(str(h5_path), strict_annotation_check=True)
+
+    def test_extra_complete_subgroup_passes(self, tmp_path: Path) -> None:
+        """An additional fully-annotated subgroup (any source) is fine."""
+        h5_path = write_valid_episode(tmp_path, stem="ep")
+        with h5py.File(h5_path, "r+") as f:
+            extra = f["episode_annotations"].require_group("cosmos-7b")
+            extra.attrs["source"] = "cosmos-7b"
+            extra.attrs["success"] = 1.0
+        assert validate_h5_file(str(h5_path), strict_annotation_check=True) is True

--- a/oopsie_tools/utils/validation/episode_validator.py
+++ b/oopsie_tools/utils/validation/episode_validator.py
@@ -184,7 +184,11 @@ def _failure_trio_fill_flags(attrs: dict[str, Any]) -> tuple[bool, bool, bool]:
 
 
 def _validate_annotations(data: EpisodeData) -> None:
-    """Each annotator subgroup must have a numeric success score in [0.0, 1.0]."""
+    """Every annotator subgroup must have a numeric success score in [0.0, 1.0].
+
+    The failure taxonomy trio (category/description/severity) is all-or-nothing, but
+    only for *failures* — a qualified success may record severity/notes on its own (#29).
+    """
     assert data.annotations, "annotations dict is empty"
 
     for annotator, attrs in data.annotations.items():
@@ -207,11 +211,13 @@ def _validate_annotations(data: EpisodeData) -> None:
             f"episode_annotations/{annotator}/success out of range [0.0, 1.0]: {success}"
         )
 
-        # TODO: Make sure this is working as expected
-        cat_ok, desc_ok, sev_ok = _failure_trio_fill_flags(attrs)
-        filled = int(cat_ok) + int(desc_ok) + int(sev_ok)
-        assert filled in (0, 3), (
-            f"episode_annotations/{annotator}: failure_category (taxonomy), "
-            f"failure_description, and severity must be all filled or all empty "
-            f"(found {filled} of 3 filled). Either complete all three or leave all three empty."
-        )
+        # The failure taxonomy trio is all-or-nothing, but only for failures;
+        # successes (including qualified successes) are exempt.
+        if success < 0.5:
+            cat_ok, desc_ok, sev_ok = _failure_trio_fill_flags(attrs)
+            filled = int(cat_ok) + int(desc_ok) + int(sev_ok)
+            assert filled in (0, 3), (
+                f"episode_annotations/{annotator}: failure_category (taxonomy), "
+                f"failure_description, and severity must be all filled or all empty "
+                f"(found {filled} of 3 filled). Either complete all three or leave all three empty."
+            )


### PR DESCRIPTION
> **Stacked on #43** (`feat/annotator-video` → #42 → #41). This PR targets that branch, so
> its diff shows only Gate 4's changes. Merge #41 → #42 → #43 → this in order.

## Summary

Turns the annotator into a data *visualizer* and lets annotators fix task text — the first
gate with server-side changes (`annotator_server.py` + `ui/annotator.html`).

- **#30 — show all logged fields:** `/api/h5/sample` now returns an `episode_fields` summary —
  root attrs, the parsed `robot_profile`, per-key **shape · dtype** for
  `observations/robot_states/*` and `actions/*` (unused actions flagged empty), video paths,
  trajectory length, and the list of annotators. It reads only attrs + dataset shapes (no array
  or video decoding), and the client shows it in a collapsible **"Episode data"** panel so you
  can confirm everything was captured correctly on the *first* episode instead of after hours of
  collection.
- **#31 — edit the task instruction:** new `POST /api/h5/instruction` (path-safety reused from
  the existing helpers) overwrites an episode's `language_instruction`; the client adds an inline
  **edit → Save/Cancel** editor next to the task instruction (Enter = save, Esc = cancel), shown
  only for a selected episode.

Hardened after an adversarial review that found three real defects in the instruction editor: it
no longer swallows the Ctrl+S annotation-save hotkey, it's reset on episode navigation (so an
open edit can't be written to the *wrong* episode), and the data panel stays in sync after a save.

Adds server tests for `episode_fields` (including `h5py.Empty` detection) and the instruction
endpoint. Full suite: 104 passed (1 unrelated sandbox path-permission quirk).

## How to verify

Launch against a directory of episodes with real observation/action logs (the two-camera fixture
works well):

```bash
uv run python -m oopsie_tools.annotation_tool.annotator_server \
  --samples-dir <samples-dir> --annotator-name test_annotator --port 5015
```
Open http://localhost:5015.

- **#30 — episode data panel:** select an episode → below the task box, expand **"Episode data"**.
  It lists the real attributes (lab_id, operator, timestamp…), the robot profile, and every
  `robot_states`/`actions` key with its **shape · dtype** (e.g. `joint_position [20, 7] · float64`;
  unused actions marked `(empty)`), plus the trajectory length and camera video paths.
- **#31 — edit instruction:** with an episode selected, click **edit** next to "Task instruction",
  type a new instruction, and **Save** (or press Enter). The header + task box update immediately;
  reload the episode → the new instruction persists (it's written into the HDF5). Pressing **Ctrl+S**
  while typing saves the *instruction* (not the annotation); navigating to another episode closes the
  editor so you can't accidentally write it to the wrong file.

Closes #30
Closes #31
