### PR TITLE
Annotation semantics: qualified success, autofill, multi-annotator (#29, #27, #26)

### DIFF
--- a/oopsie_tools/annotation_tool/annotation_schema.py
+++ b/oopsie_tools/annotation_tool/annotation_schema.py
@@ -1,0 +1,43 @@
+"""Single definition of how a human annotation is written into an episode HDF5.
+
+Kept in a dependency-light module (json + h5py only) so both the in-the-loop
+recorder patch and the web annotator server can share it without either pulling in
+the other's heavier imports.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import h5py
+
+
+def write_annotation_attrs(group: h5py.Group, annotation: dict[str, Any]) -> None:
+    """Write the oopsie annotation attribute set onto an ``episode_annotations`` subgroup.
+
+    ``binary_success`` maps to the numeric ``success`` attr (1.0/0.0); the failure
+    taxonomy plus the optional qualified-success category live in the ``taxonomy`` JSON.
+    Missing keys fall back to safe defaults, and a ``None`` success (an unrecognized
+    ``binary_success``) is left unwritten rather than crashing h5py.
+    """
+    bs = str(annotation.get("binary_success", "")).strip().lower()
+    success = 1.0 if bs == "success" else 0.0 if bs == "failure" else None
+
+    group.attrs["schema"] = annotation.get("schema", "oopsie_failure_taxonomy_v1")
+    group.attrs["source"] = annotation.get("source", "human")
+    group.attrs["timestamp"] = annotation.get("annotated_at", annotation.get("timestamp", ""))
+    if success is not None:
+        group.attrs["success"] = float(success)
+    group.attrs["failure_description"] = annotation.get("failure_description", "")
+
+    taxonomy: dict[str, Any] = {
+        "failure_category": annotation.get("failure_category", []),
+        "severity": annotation.get("severity", ""),
+    }
+    success_category = str(annotation.get("success_category", "") or "").strip()
+    if success_category:
+        taxonomy["success_category"] = success_category
+    group.attrs["taxonomy_schema"] = "oopsiedata_taxonomy_schema_v1"
+    group.attrs["taxonomy"] = json.dumps(taxonomy, ensure_ascii=False)
+    group.attrs["additional_notes"] = annotation.get("additional_notes", "")

--- a/oopsie_tools/annotation_tool/annotator_server.py
+++ b/oopsie_tools/annotation_tool/annotator_server.py
@@ -34,6 +34,7 @@ import yaml
 from flask import Flask, abort, jsonify, request, send_file
 
 from oopsie_tools.annotation_tool import QUESTIONNAIRE_PATH
+from oopsie_tools.annotation_tool.annotation_schema import write_annotation_attrs
 
 app = Flask(__name__)
 
@@ -414,6 +415,9 @@ def _read_existing_annotation_dict(ea: h5py.Group, annotator_name: str) -> dict[
         sev = tax.get("severity")
         if sev is not None:
             existing_annotation["severity"] = str(sev)
+        sc = tax.get("success_category")
+        if sc is not None:
+            existing_annotation["success_category"] = str(sc)
 
     if not existing_annotation:
         raw_failure = _read_h5_attr(ea, "failure_annotation", "")
@@ -534,6 +538,25 @@ def _summarize_episode_fields(h5f: h5py.File) -> dict[str, Any]:
     return fields
 
 
+def _has_other_human_annotation(h5f: h5py.File, annotator_name: str) -> bool:
+    """Whether a human other than ``annotator_name`` has annotated this episode (#26)."""
+    ea = h5f.get("episode_annotations")
+    if not isinstance(ea, h5py.Group):
+        return False
+    for name in ea.keys():
+        if name == annotator_name:
+            continue
+        sub = ea[name]
+        if not isinstance(sub, h5py.Group):
+            continue
+        source = str(_read_h5_attr(sub, "source", "") or "").strip().lower()
+        if source and source != "human":
+            continue  # VLM / automated annotators don't count as "another annotator"
+        if _annotator_subgroup_looks_annotated(sub):
+            return True
+    return False
+
+
 @app.get("/api/h5/list")
 def api_h5_list():
     rt = _get_runtime()
@@ -544,11 +567,14 @@ def api_h5_list():
             continue
         rel = p.resolve().relative_to(root).as_posix()
         tick_level = 0
+        others = False
         try:
             with h5py.File(p, "r") as h5f:
                 tick_level = _h5_annotation_tick_level(h5f, rt.cfg.annotator_name)
+                others = _has_other_human_annotation(h5f, rt.cfg.annotator_name)
         except Exception:
             tick_level = 0
+            others = False
         annotated = tick_level >= 1
         entries.append(
             {
@@ -558,10 +584,63 @@ def api_h5_list():
                 "mtime": p.stat().st_mtime,
                 "annotated": annotated,
                 "annotation_tick_level": tick_level,
+                "annotated_by_others": others,
             }
         )
     entries.sort(key=lambda e: e.get("rel_path") or "")
     return jsonify(entries)
+
+
+@app.get("/api/annotations/recent")
+def api_recent_annotations():
+    """The current annotator's recent distinct annotations, for the autofill picker (#27)."""
+    rt = _get_runtime()
+    root = rt.cfg.samples_dir.resolve()
+    ann_name = rt.cfg.annotator_name
+    try:
+        limit = int(request.args.get("limit", 15))
+    except (TypeError, ValueError):
+        limit = 15
+    limit = max(1, min(limit, 100))
+
+    files = [p for p in root.rglob("*.h5") if p.is_file()]
+    files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+
+    seen: set[str] = set()
+    recent: list[dict[str, Any]] = []
+    for p in files:
+        if len(recent) >= limit:
+            break
+        try:
+            with h5py.File(p, "r") as h5f:
+                ea = h5f.get("episode_annotations")
+                if not isinstance(ea, h5py.Group):
+                    continue
+                # Only the current annotator's OWN subgroup — never the legacy
+                # episode-level failure_annotation fallback, which isn't
+                # annotator-scoped and could surface someone else's labels (#27).
+                if ann_name not in ea.keys() or not isinstance(ea[ann_name], h5py.Group):
+                    continue
+                ann = _read_existing_annotation_dict(ea, ann_name)
+        except Exception:
+            continue
+        if not ann or not str(ann.get("binary_success", "")).strip():
+            continue
+        key = json.dumps(
+            {
+                "binary_success": str(ann.get("binary_success", "")).strip(),
+                "success_category": str(ann.get("success_category", "")).strip(),
+                "failure_category": sorted(str(x) for x in (ann.get("failure_category") or [])),
+                "severity": str(ann.get("severity", "")).strip(),
+                "failure_description": str(ann.get("failure_description", "")).strip(),
+            },
+            sort_keys=True,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        recent.append(ann)
+    return jsonify(recent)
 
 
 @app.get("/api/h5/sample")
@@ -652,32 +731,11 @@ def api_h5_save_annotation():
 
     ann = rt.save_annotation(sample_id=str(h5_path), payload=payload)
 
-    success: float | None = None
-    bs = str(ann.get("binary_success", "")).strip().lower()
-    if bs == "success":
-        success = 1.0
-    elif bs == "failure":
-        success = 0.0
-
     try:
         with h5py.File(h5_path, "r+") as f:
             ea = f.require_group("episode_annotations")
             ag = ea.require_group(ann["annotator"])
-            ag.attrs["schema"] = ann.get("schema", "oopsie_failure_taxonomy_v1")
-            ag.attrs["source"] = "human"
-            ag.attrs["timestamp"] = ann["annotated_at"]
-            if success is not None:
-                ag.attrs["success"] = float(success)
-            ag.attrs["failure_description"] = ann.get("failure_description", "")
-            ag.attrs["taxonomy_schema"] = "oopsiedata_taxonomy_schema_v1"
-            ag.attrs["taxonomy"] = json.dumps(
-                {
-                    "failure_category": ann.get("failure_category", []),
-                    "severity": ann.get("severity", ""),
-                },
-                ensure_ascii=False,
-            )
-            ag.attrs["additional_notes"] = ann.get("additional_notes", "")
+            write_annotation_attrs(ag, ann)
     except OSError as e:
         return jsonify({"error": f"could not write HDF5: {e}"}), 500
     except Exception as e:

--- a/oopsie_tools/annotation_tool/episode_recorder.py
+++ b/oopsie_tools/annotation_tool/episode_recorder.py
@@ -13,6 +13,7 @@ import imageio
 import numpy as np
 import datetime
 import yaml
+from oopsie_tools.annotation_tool.annotation_schema import write_annotation_attrs
 from oopsie_tools.utils.robot_profile.robot_profile import RobotProfile, robot_profile_to_json
 from oopsie_tools.utils.robot_profile.rotation_utils import ActionQuatConversion
 from oopsie_tools.utils.validation.episode_data import EpisodeData, VideoInfo
@@ -679,38 +680,12 @@ class EpisodeRecorder:
         if not h5_path.exists():
             raise FileNotFoundError(str(h5_path))
 
-        success: float | None = None
-        bs = str(annotation.get("binary_success", "")).strip().lower()
-        if bs == "success":
-            success = 1.0
-        elif bs == "failure":
-            success = 0.0
-
         with h5py.File(h5_path, "r+") as f:
             episode_annotations = f.require_group("episode_annotations")
             annotation_group = episode_annotations.require_group(
                 annotation["annotator"]
             )
-            annotation_group.attrs["schema"] = annotation.get("schema", "oopsie_failure_taxonomy_v1")
-            annotation_group.attrs["source"] = "human"
-            annotation_group.attrs["timestamp"] = annotation["annotated_at"]
-            annotation_group.attrs["success"] = success
-            annotation_group.attrs["failure_description"] = annotation[
-                "failure_description"
-            ]
-            annotation_group.attrs["taxonomy_schema"] = "oopsiedata_taxonomy_schema_v1"
-            failure_taxonomy = {
-                "failure_category": annotation["failure_category"],
-                "severity": annotation["severity"],
-            }
-            annotation_group.attrs["taxonomy"] = json.dumps(
-                failure_taxonomy, ensure_ascii=False
-            )
-            annotation_group.attrs["additional_notes"] = annotation["additional_notes"]
-
-            # annotation_group.attrs["failure_annotation"] = json.dumps(
-            #     dict(annotation), ensure_ascii=False
-            # )
+            write_annotation_attrs(annotation_group, annotation)
 
     @property
     def num_steps(self) -> int:

--- a/oopsie_tools/annotation_tool/templates/questionnaire.yaml
+++ b/oopsie_tools/annotation_tool/templates/questionnaire.yaml
@@ -8,15 +8,33 @@ questions:
       - "Success"
       - "Failure"
 
+  - id: success_category
+    type: radio
+    label: "Success quality"
+    required: false
+    show_when:
+      binary_success: ["Success"]
+    options:
+      - name: "Clean success"
+        long_form: "Task completed correctly with no notable side-effects or inefficiencies."
+      - name: "Success with side-effects"
+        long_form: "Task completed, but with unintended side-effects (e.g. knocked over a nearby object, minor collision) that did not prevent completion."
+      - name: "Suboptimal execution"
+        long_form: "Task completed, but inefficiently or awkwardly (e.g. many retries, a very indirect path, near-misses)."
+
   - id: failure_description
     type: textarea
     label: "Describe what went wrong"
     required: false
+    show_when:
+      binary_success: ["Failure"]
 
   - id: failure_category
     type: checkbox
     label: "Failure categories (select all that apply)"
     required: false
+    show_when:
+      binary_success: ["Failure"]
     options:
       - name: "Reaching failure (pre contact)"
         long_form: "Failure to reach the target object or location, resulting in no contact being made. If a grasp just barely misses the object, please count this as a grasp failure rather than a reaching failure."
@@ -37,8 +55,10 @@ questions:
 
   - id: severity
     type: radio
-    label: "How severe is this failure?"
+    label: "Severity (failure impact, or success side-effects)"
     required: false
+    show_when:
+      binary_success: ["Failure", "Success"]
     options:
       - "Low severity - no damage, can be reset and reattempted"
       - "Medium severity - some damage or risk of damage or significant reset required, but can be reattempted"

--- a/oopsie_tools/annotation_tool/ui/annotator.html
+++ b/oopsie_tools/annotation_tool/ui/annotator.html
@@ -267,6 +267,7 @@
       .tree-label { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
 
       .tick { color: #4ade80; font-weight: 800; }
+      .other-mark { color: #a78bfa; font-weight: 800; }
 
       /* Videos: equal sizing */
       /* Videos: vertical stack for larger size */
@@ -344,6 +345,11 @@
       .ef-key { flex: 0 0 42%; color: #94a3b8; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-word; }
       .ef-val { flex: 1; color: #cbd5e1; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-word; }
 
+      /* Autofill from a previous annotation (#27) */
+      #autofillRow { margin-bottom: 16px; }
+      .autofill-label { display: block; font-size: 0.8rem; color: #94a3b8; font-weight: 500; }
+      .autofill-label select { margin-top: 4px; }
+
       /* Editable task instruction (#31) */
       .link-btn { background: none; border: none; color: #60a5fa; font-size: 0.7rem; padding: 0 0 0 6px; font-weight: 600; cursor: pointer; }
       .link-btn:hover { background: none; text-decoration: underline; }
@@ -406,6 +412,7 @@
           <div class="h5-legend" aria-label="Annotation status icons">
             <div class="h5-legend-row"><span class="tick">✓</span> Only Success/failure Annotated (failure details incomplete).</div>
             <div class="h5-legend-row"><span class="tick">✓✓</span> Complete: Success/failure Annotated with description, category, and severity.</div>
+            <div class="h5-legend-row"><span class="other-mark">◆</span> Also annotated by another annotator.</div>
           </div>
           <input id="h5Search" class="h5-search" type="text" placeholder="Search…" />
           <div class="h5-nav">
@@ -463,6 +470,11 @@
             </div>
             <div id="metadataPanel" style="display:none;"></div>
             <div id="episodeFields" style="display:none;"></div>
+            <div id="autofillRow" style="display:none;">
+              <label class="autofill-label">Copy from a previous annotation
+                <select id="autofillSelect"><option value="">— select —</option></select>
+              </label>
+            </div>
             <div id="questionnaire"></div>
           </div>
           <div class="save-bar" id="saveBar">
@@ -569,9 +581,12 @@
         if (which === "annotateCard") {
           el("questionnaire").style.display = "";
           el("saveBar").style.display = "";
+          el("autofillRow").style.display =
+            (window.__recentAnnotations && window.__recentAnnotations.length) ? "" : "none";
         } else {
           el("metadataPanel").style.display = "none";
           el("episodeFields").style.display = "none";
+          el("autofillRow").style.display = "none";
           el("questionnaire").style.display = "none";
           el("saveBar").style.display = "none";
         }
@@ -752,6 +767,40 @@
             ${section("Other", kvRows({ trajectory_length: fields.trajectory_length, annotators: (fields.annotators || []).join(", ") }))}
           </details>`;
         panel.style.display = "";
+      }
+
+      // ── Autofill from a previous annotation (#27) ──────────────────────────
+      async function loadRecentAnnotations() {
+        try {
+          const items = await jget("/api/annotations/recent?limit=15");
+          window.__recentAnnotations = Array.isArray(items) ? items : [];
+        } catch (e) {
+          window.__recentAnnotations = [];
+        }
+        renderAutofillOptions();
+      }
+      function annotationSummaryLabel(a) {
+        const bs = String(a?.binary_success || "").trim() || "?";
+        if (bs === "Failure") {
+          const cats = (a.failure_category || []).join(", ");
+          const desc = String(a.failure_description || "").trim();
+          return `Failure — ${cats || "(no category)"}${desc ? ": " + desc.slice(0, 60) : ""}`;
+        }
+        const sc = String(a?.success_category || "").trim();
+        return `Success${sc ? " — " + sc : ""}`;
+      }
+      function renderAutofillOptions() {
+        const sel = el("autofillSelect");
+        const row = el("autofillRow");
+        if (!sel || !row) return;
+        const items = window.__recentAnnotations || [];
+        sel.innerHTML = items.length
+          ? '<option value="">— copy from a previous annotation —</option>' +
+            items.map((a, i) => `<option value="${i}">${escHtml(annotationSummaryLabel(a))}</option>`).join("")
+          : '<option value="">— select —</option>';
+        // Only surface the picker while annotating; showOnly also manages this.
+        const annotating = el("annotateCard").style.display !== "none";
+        row.style.display = (items.length && annotating) ? "" : "none";
       }
 
       function inputForQuestion(q) {
@@ -948,8 +997,14 @@
       }
 
       function validateSaveAnswers(answers) {
-        if (!String(answers?.binary_success ?? "").trim()) {
+        const bs = String(answers?.binary_success ?? "").trim();
+        if (!bs) {
           return "Please annotate success/failure.";
+        }
+        // The failure taxonomy trio is all-or-nothing, but only for failures — a
+        // (qualified) success may set severity/notes independently (#29).
+        if (bs !== "Failure") {
+          return "";
         }
         const categoryFilled =
           Array.isArray(answers?.failure_category) && answers.failure_category.length > 0;
@@ -962,16 +1017,31 @@
         return "";
       }
 
-      const FAILURE_ONLY_QUESTIONS = ["failure_category", "failure_description", "severity"];
+      function questionCurrentValue(id) {
+        const checked = document.querySelector(`input[type="radio"][name="${CSS.escape(id)}"]:checked`);
+        if (checked) return checked.value;
+        const other = document.querySelector(`[name="${CSS.escape(id)}"]`);
+        return other ? String(other.value ?? "") : "";
+      }
 
+      // Data-driven conditional visibility (#29): a question with
+      // `show_when: {binary_success: [...]}` is shown only when every referenced
+      // question currently holds one of the listed values. Questions without a
+      // `show_when` are always visible. Generalizes the old hard-coded failure hide.
       function applySuccessConditional() {
-        const selected = document.querySelector('input[type="radio"][name="binary_success"]:checked');
-        const isSuccess = selected && selected.value === "Success";
-        FAILURE_ONLY_QUESTIONS.forEach((id) => {
+        const qs = Array.isArray(window.__questionnaireSpec?.questions) ? window.__questionnaireSpec.questions : [];
+        for (const q of qs) {
+          const id = q.id || q.name || q.key;
+          const cond = q && q.show_when;
+          if (!id || !cond || typeof cond !== "object") continue;
           const group = document.querySelector(`[data-question-id="${CSS.escape(id)}"]`);
-          if (!group) return;
-          group.style.display = isSuccess ? "none" : "";
-        });
+          if (!group) continue;
+          const visible = Object.entries(cond).every(([depId, allowed]) => {
+            const vals = Array.isArray(allowed) ? allowed.map(String) : [String(allowed)];
+            return vals.includes(questionCurrentValue(depId));
+          });
+          group.style.display = visible ? "" : "none";
+        }
       }
 
       let currentSampleId = null; // rollout sample_id
@@ -1072,7 +1142,7 @@
           const items = await jget("/api/h5/list");
           const arr = Array.isArray(items) ? items : [];
           // Lightweight signature: rel_path + annotated + mtime.
-          const sig = arr.map(it => `${it.rel_path}|${Number(it.annotation_tick_level ?? 0)}|${it.mtime}`).join("\n");
+          const sig = arr.map(it => `${it.rel_path}|${Number(it.annotation_tick_level ?? 0)}|${it.annotated_by_others ? 1 : 0}|${it.mtime}`).join("\n");
           if (sig !== lastH5ListSig) {
             lastH5ListSig = sig;
             window.__h5Items = arr;
@@ -1155,11 +1225,14 @@
             const active = (browseRelPath === rp) ? "active" : "";
             const tl = Number(it.annotation_tick_level ?? 0);
             const tick = tl >= 2 ? "✓✓ " : tl >= 1 ? "✓ " : "";
+            const other = it.annotated_by_others
+              ? '<span class="other-mark" title="Also annotated by another annotator">◆</span> '
+              : "";
             const indent = depth * 14;
             lines.push(
               `<div class="tree-row ${active}" data-kind="file" data-rel="${esc(rp)}" style="margin-left:${indent}px;">` +
               `<span class="tree-arrow"></span>` +
-              `<span class="tree-label">${tick}${esc(it._fileName)}</span>` +
+              `<span class="tree-label">${other}${tick}${esc(it._fileName)}</span>` +
               `</div>`
             );
           }
@@ -1203,6 +1276,20 @@
         const ann = existing && typeof existing === "object" ? existing : {};
         const skip = new Set(["annotated_at", "annotator", "source"]);
         const qs = Array.isArray(window.__questionnaireSpec?.questions) ? window.__questionnaireSpec.questions : [];
+        // Reset every managed field first so applying a (possibly partial) annotation —
+        // e.g. copying a previous annotation onto an already-filled form (#27) — never
+        // leaves stale values (like a success_category) from a prior selection.
+        for (const q of qs) {
+          const id = q.id || q.name || q.key;
+          if (!id || skip.has(id)) continue;
+          const type = String(q.type || "text").toLowerCase();
+          if (type === "checkbox" || type === "radio") {
+            document.querySelectorAll(`input[name="${CSS.escape(id)}"]`).forEach((e) => { e.checked = false; });
+          } else {
+            const el0 = document.querySelector(`[name="${CSS.escape(id)}"]`);
+            if (el0) el0.value = "";
+          }
+        }
         for (const q of qs) {
           const id = q.id || q.name || q.key;
           if (!id || skip.has(id)) continue;
@@ -1420,6 +1507,7 @@
           el("saveMsg").textContent = "";
           markSaved();
           await pollH5List();
+          loadRecentAnnotations().catch(() => {}); // the just-saved annotation becomes copyable
           if (browseRelPath && autoAdvanceEnabled()) {
             await navigateBy(1);
           }
@@ -1446,6 +1534,18 @@
         el("instrEditInput").focus();
       });
       el("instrCancelBtn").addEventListener("click", () => { el("instrEditRow").style.display = "none"; });
+
+      // Autofill: copy a chosen previous annotation into the form (#27)
+      el("autofillSelect").addEventListener("change", () => {
+        const items = window.__recentAnnotations || [];
+        const idx = parseInt(el("autofillSelect").value, 10);
+        if (Number.isInteger(idx) && items[idx]) {
+          populateForm(items[idx]);
+          setDirty(true);
+          el("saveMsg").textContent = "Copied from a previous annotation — review and Save.";
+        }
+        el("autofillSelect").value = "";
+      });
       el("instrSaveBtn").addEventListener("click", async () => {
         if (!browseRelPath) return;
         const val = el("instrEditInput").value.trim();
@@ -1554,6 +1654,7 @@
       }
 
       loadH5List().catch(() => {});
+      loadRecentAnnotations().catch(() => {});
       if (typeof ANNOTATOR_BROWSE_ONLY === "undefined" || !ANNOTATOR_BROWSE_ONLY) {
         setInterval(() => refresh().catch(() => {}), 800);
         setInterval(() => pollH5List().catch(() => {}), 1500);

--- a/oopsie_tools/test/test_annotator_server.py
+++ b/oopsie_tools/test/test_annotator_server.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import h5py
 import pytest
 
+from oopsie_tools.annotation_tool.annotation_schema import write_annotation_attrs
 from oopsie_tools.annotation_tool.annotator_server import app, configure_runtime
 from oopsie_tools.test.fixtures.make_valid import (
     _write_base_h5,
@@ -104,3 +105,80 @@ def test_set_instruction_rejects_empty(client, tmp_path: Path) -> None:
     resp = client.post("/api/h5/instruction?path=ep.h5", json={"instruction": "  "})
 
     assert resp.status_code == 400
+
+
+def test_save_success_category_roundtrip(client, tmp_path: Path) -> None:
+    """A qualified success stores success_category in the taxonomy and reads back (#29)."""
+    write_valid_episode(tmp_path, stem="ep")
+
+    resp = client.post(
+        "/api/h5/annotations?path=ep.h5",
+        json={
+            "binary_success": "Success",
+            "success_category": "Success with side-effects",
+            "severity": "Low severity - no damage, can be reset and reattempted",
+            "failure_category": [],
+            "failure_description": "",
+            "additional_notes": "clipped a nearby cup",
+        },
+    )
+    assert resp.status_code == 200, resp.data
+
+    data = _get_sample(client, "ep.h5")
+    assert data["metadata"]["success"] == 1.0
+    ann = data["existing_annotation"]
+    assert ann["binary_success"] == "Success"
+    assert ann["success_category"] == "Success with side-effects"
+    assert ann["severity"].startswith("Low severity")
+
+
+def test_recent_annotations_returns_distinct(client, tmp_path: Path) -> None:
+    """/api/annotations/recent surfaces the annotator's distinct prior labels (#27)."""
+    write_valid_episode(tmp_path, stem="a")  # success by test_annotator
+    write_valid_episode(tmp_path, stem="b")
+    client.post(
+        "/api/h5/annotations?path=b.h5",
+        json={
+            "binary_success": "Failure",
+            "failure_category": ["Other"],
+            "failure_description": "dropped the object",
+            "severity": "Low severity - no damage, can be reset and reattempted",
+        },
+    )
+
+    items = client.get("/api/annotations/recent?limit=10").get_json()
+    kinds = {i["binary_success"] for i in items}
+
+    assert "Success" in kinds and "Failure" in kinds
+
+
+def test_list_reports_other_human_annotator(client, tmp_path: Path) -> None:
+    """api_h5_list flags episodes annotated by a different human (#26)."""
+    write_valid_episode(tmp_path, stem="ep")  # annotated by test_annotator
+    with h5py.File(tmp_path / "ep.h5", "r+") as f:
+        g = f["episode_annotations"].require_group("someone_else")
+        write_annotation_attrs(
+            g,
+            {
+                "binary_success": "Failure",
+                "source": "human",
+                "failure_category": ["Other"],
+                "failure_description": "x",
+                "severity": "Low severity - no damage, can be reset and reattempted",
+            },
+        )
+
+    entry = next(e for e in client.get("/api/h5/list").get_json() if e["rel_path"] == "ep.h5")
+    assert entry["annotated_by_others"] is True
+
+
+def test_list_ignores_nonhuman_annotator(client, tmp_path: Path) -> None:
+    """VLM/automated subgroups do not count as 'another annotator' (#26)."""
+    write_valid_episode(tmp_path, stem="ep")
+    with h5py.File(tmp_path / "ep.h5", "r+") as f:
+        g = f["episode_annotations"].require_group("cosmos-7b")
+        g.attrs["source"] = "cosmos-7b"
+        g.attrs["success"] = 0.0
+
+    entry = next(e for e in client.get("/api/h5/list").get_json() if e["rel_path"] == "ep.h5")
+    assert entry["annotated_by_others"] is False

--- a/oopsie_tools/test/test_validate.py
+++ b/oopsie_tools/test/test_validate.py
@@ -17,9 +17,11 @@ TestValidateSessionDir    – directory-level validation
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
+import h5py
 import pytest
 
 _VALIDATE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "validate_and_upload"
@@ -151,7 +153,7 @@ class TestTrajectoryLengths:
     def test_zero_trajectory_via_tmp_path(self, tmp_path):
         h5_path = write_valid_episode(tmp_path, "zero", n=0)
         with pytest.raises(AssertionError):
-            validate_h5_file(str(h5_path))
+            validate_h5_file(str(h5_path), strict_annotation_check=True)
 
 
 # ---------------------------------------------------------------------------
@@ -248,3 +250,56 @@ class TestValidateSessionDir:
         write_valid_episode(tmp_path, "ep_a")
         write_valid_episode(tmp_path, "ep_b")
         assert validate_session_dir(str(tmp_path)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Annotation semantics (#29 qualified success, #26 multi/non-human annotators)
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationSemantics:
+    def test_success_with_standalone_severity_passes(self, tmp_path: Path) -> None:
+        """A qualified success may set severity without the failure trio (#29)."""
+        h5_path = write_valid_episode(tmp_path, stem="ep")
+        with h5py.File(h5_path, "r+") as f:
+            g = f["episode_annotations"]["test_annotator"]
+            g.attrs["success"] = 1.0
+            g.attrs["taxonomy"] = json.dumps(
+                {
+                    "failure_category": [],
+                    "severity": "Low severity - no damage, can be reset and reattempted",
+                    "success_category": "Success with side-effects",
+                }
+            )
+        assert validate_h5_file(str(h5_path), strict_annotation_check=True) is True
+
+    def test_failure_still_requires_full_trio(self, tmp_path: Path) -> None:
+        """A failure with only severity (partial trio) is still rejected."""
+        h5_path = write_valid_episode(tmp_path, stem="ep")
+        with h5py.File(h5_path, "r+") as f:
+            g = f["episode_annotations"]["test_annotator"]
+            g.attrs["success"] = 0.0
+            g.attrs["failure_description"] = ""
+            g.attrs["taxonomy"] = json.dumps(
+                {"failure_category": [], "severity": "Low severity - no damage, can be reset and reattempted"}
+            )
+        with pytest.raises(AssertionError, match="all filled or all empty"):
+            validate_h5_file(str(h5_path), strict_annotation_check=True)
+
+    def test_incomplete_extra_subgroup_fails(self, tmp_path: Path) -> None:
+        """Every annotator subgroup must be complete: a stray incomplete one fails the episode."""
+        h5_path = write_valid_episode(tmp_path, stem="ep")
+        with h5py.File(h5_path, "r+") as f:
+            extra = f["episode_annotations"].require_group("cosmos-7b")
+            extra.attrs["source"] = "cosmos-7b"  # no 'success' → incomplete subgroup
+        with pytest.raises(AssertionError, match="missing 'success'"):
+            validate_h5_file(str(h5_path), strict_annotation_check=True)
+
+    def test_extra_complete_subgroup_passes(self, tmp_path: Path) -> None:
+        """An additional fully-annotated subgroup (any source) is fine."""
+        h5_path = write_valid_episode(tmp_path, stem="ep")
+        with h5py.File(h5_path, "r+") as f:
+            extra = f["episode_annotations"].require_group("cosmos-7b")
+            extra.attrs["source"] = "cosmos-7b"
+            extra.attrs["success"] = 1.0
+        assert validate_h5_file(str(h5_path), strict_annotation_check=True) is True

--- a/oopsie_tools/utils/validation/episode_validator.py
+++ b/oopsie_tools/utils/validation/episode_validator.py
@@ -184,7 +184,11 @@ def _failure_trio_fill_flags(attrs: dict[str, Any]) -> tuple[bool, bool, bool]:
 
 
 def _validate_annotations(data: EpisodeData) -> None:
-    """Each annotator subgroup must have a numeric success score in [0.0, 1.0]."""
+    """Every annotator subgroup must have a numeric success score in [0.0, 1.0].
+
+    The failure taxonomy trio (category/description/severity) is all-or-nothing, but
+    only for *failures* — a qualified success may record severity/notes on its own (#29).
+    """
     assert data.annotations, "annotations dict is empty"
 
     for annotator, attrs in data.annotations.items():
@@ -207,11 +211,13 @@ def _validate_annotations(data: EpisodeData) -> None:
             f"episode_annotations/{annotator}/success out of range [0.0, 1.0]: {success}"
         )
 
-        # TODO: Make sure this is working as expected
-        cat_ok, desc_ok, sev_ok = _failure_trio_fill_flags(attrs)
-        filled = int(cat_ok) + int(desc_ok) + int(sev_ok)
-        assert filled in (0, 3), (
-            f"episode_annotations/{annotator}: failure_category (taxonomy), "
-            f"failure_description, and severity must be all filled or all empty "
-            f"(found {filled} of 3 filled). Either complete all three or leave all three empty."
-        )
+        # The failure taxonomy trio is all-or-nothing, but only for failures;
+        # successes (including qualified successes) are exempt.
+        if success < 0.5:
+            cat_ok, desc_ok, sev_ok = _failure_trio_fill_flags(attrs)
+            filled = int(cat_ok) + int(desc_ok) + int(sev_ok)
+            assert filled in (0, 3), (
+                f"episode_annotations/{annotator}: failure_category (taxonomy), "
+                f"failure_description, and severity must be all filled or all empty "
+                f"(found {filled} of 3 filled). Either complete all three or leave all three empty."
+            )


### PR DESCRIPTION
> **Stacked on #44** (`feat/annotator-visibility` → #43 → #42 → #41). Merge the chain in order.

## Summary

Extends the annotation *model* — the biggest gate — while staying **backward-compatible with
existing episodes (no data migration)**.

**Shared writer.** `annotation_schema.write_annotation_attrs` now defines the stored annotation
attribute set in one place, used by both the in-the-loop recorder patch and the web annotator
server. This removes prior drift and fixes the recorder's unconditional `None`-success write and
brittle hard-indexing.

- **#29 — qualified / more success categories.** Questionnaire questions gain data-driven
  `show_when: {binary_success: [...]}` visibility (replacing the hard-coded failure-only hide) and
  a new optional **`success_category`** radio (Clean success / Success with side-effects /
  Suboptimal execution); **severity** is now offered on successes too. `success_category` is stored
  inside the existing `taxonomy` JSON and `success` stays a strict binary float — so old files stay
  valid. The failure-taxonomy trio (category+description+severity) all-or-nothing rule now applies
  **only to failures** (frontend and validator), so a qualified success can record severity/notes
  independently.
- **#27 — autofill old annotations.** `GET /api/annotations/recent` returns the current
  annotator's recent *distinct* annotations; a **"Copy from a previous annotation"** picker fills
  the form (for recurring failure modes). The form is fully reset before a copy is applied.
- **#26 — multi-annotator.** `/api/h5/list` reports `annotated_by_others` (human annotators only —
  VLM/automated subgroups don't count) and the file list shows a distinct **◆ badge** + legend.
  Both annotations are kept (storage was already keyed by annotator).

### Validation policy: unchanged
Upload validation still requires **every** annotator subgroup present to be complete, exactly as
before. This PR only makes the failure taxonomy trio **success-exempt**, so a qualified success can
record severity/notes without a failure category/description. (An earlier revision of this PR
relaxed the multi-annotator policy to "skip non-human subgroups, require ≥1 human"; that was
reverted after review — the original every-subgroup-complete rule stands.)

## How to verify

Launch against multi-camera episodes (a fixture that includes a second human annotator + a VLM
subgroup makes #26 visible):

```bash
uv run python -m oopsie_tools.annotation_tool.annotator_server \
  --samples-dir <samples-dir> --annotator-name test_annotator --port 5016
```
Open http://localhost:5016.

- **#29 — qualified success:** select an episode, choose **Success** → a **"Success quality"**
  radio appears (Clean / side-effects / suboptimal) and **Severity** is available; the failure
  fields are hidden. Choose **Failure** → success-quality hides, the failure fields (description /
  categories / severity) appear and remain all-or-nothing. Save a qualified success (quality +
  severity, no failure fields) → it saves and reloads with those values.
- **#27 — autofill:** annotate one episode as a Failure with a category/description, go to another
  episode, and use **"Copy from a previous annotation"** → the form fills with that prior
  annotation; adjust and Save.
- **#26 — multi-annotator:** an episode annotated by another *human* shows a purple **◆** next to
  its name (see the legend); an episode carrying only a VLM/automated subgroup does **not**. Your
  own annotation still saves alongside theirs.
- **Backward-compat / validation:** `uv run pytest oopsie_tools/test/` stays green; existing
  success/failure episodes still validate; a *failure* with a partial trio is still rejected.

Closes #29
Closes #27
Closes #26
