### PR TITLE
Validation & upload developer experience (#20, #21, #37, #40)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -153,7 +153,8 @@ This validates and pushes episodes to the lab-specific HuggingFace repository.
 
 ## Common mistakes to catch
 
-- `lab_id` capitalisation mismatch → `RuntimeError` at `EpisodeRecorder.__init__`.
+- `lab_id` unset, blank (`lab_id:`), or still the placeholder in `configs/contributor_config.yaml` → a clear `RuntimeError` (pointing to the registration form) at `EpisodeRecorder.__init__` and when running `upload.py`. Capitalisation must match exactly the value you were given.
+- After uploading, run `python scripts/validate_and_upload/query_submissions.py` to confirm your episodes landed in the lab HuggingFace repo.
 - Action dict keys not matching `action_space` in the robot profile → validation error at `record_step`.
 - Passing an action chunk instead of per-step actions → validation error.
 - `cartesian_position` in state/action but `orientation_representation` not set → conversion will fail.

--- a/oopsie_tools/annotation_tool/episode_recorder.py
+++ b/oopsie_tools/annotation_tool/episode_recorder.py
@@ -13,6 +13,7 @@ import imageio
 import numpy as np
 import datetime
 import yaml
+from oopsie_tools.utils.contributor_config import read_contributor_config
 from oopsie_tools.utils.robot_profile.robot_profile import RobotProfile, robot_profile_to_json
 from oopsie_tools.utils.robot_profile.rotation_utils import ActionQuatConversion
 from oopsie_tools.utils.validation.episode_data import EpisodeData, VideoInfo
@@ -121,24 +122,7 @@ class EpisodeRecorder:
         # Timestep data buffer
         self.timesteps: list[dict[str, Any]] = []
 
-        # Read lab_id from configs/contributor_config.yaml
-        try:
-            config_path = (
-                Path(__file__).resolve().parent.parent.parent
-                / "configs"
-                / "contributor_config.yaml"
-            )
-            with open(config_path, "r") as f:
-                config = yaml.safe_load(f)
-                self.lab_id = config.get("lab_id", "").strip()
-                if not self.lab_id:
-                    raise ValueError(
-                        "lab_id must be set in configs/contributor_config.yaml"
-                    )
-        except Exception as e:
-            raise RuntimeError(
-                f"Could not read lab_id from configs/contributor_config.yaml: {e}"
-            )
+        self.lab_id, _ = read_contributor_config()
 
     def reset_episode_recorder(self) -> None:
         """Reset the buffers for a new episode."""

--- a/oopsie_tools/test/conftest.py
+++ b/oopsie_tools/test/conftest.py
@@ -32,6 +32,29 @@ from oopsie_tools.test.fixtures.make_invalid import (
 __all__ = ["write_valid_episode"]
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _test_contributor_config():
+    """Supply a test lab_id everywhere the contributor config is read.
+
+    Lets the suite run on a fresh checkout without a filled-in
+    ``configs/contributor_config.yaml`` (whose blank lab_id would otherwise fail
+    ``EpisodeRecorder`` construction), without touching the committed file.
+    """
+    import oopsie_tools.utils.contributor_config as _cc
+    import oopsie_tools.annotation_tool.episode_recorder as _recorder
+
+    def _fake(config_path=None) -> tuple[str, str]:
+        return ("test_lab", "test_token")
+
+    originals = (_cc.read_contributor_config, _recorder.read_contributor_config)
+    _cc.read_contributor_config = _fake
+    _recorder.read_contributor_config = _fake
+    try:
+        yield
+    finally:
+        _cc.read_contributor_config, _recorder.read_contributor_config = originals
+
+
 # ---------------------------------------------------------------------------
 # Session-scoped fixtures: valid episodes
 # ---------------------------------------------------------------------------

--- a/oopsie_tools/test/test_contributor_config.py
+++ b/oopsie_tools/test/test_contributor_config.py
@@ -1,0 +1,38 @@
+"""Tests for the shared contributor-config reader (issue #20)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from oopsie_tools.utils.contributor_config import read_contributor_config
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "contributor_config.yaml"
+    path.write_text(content)
+    return path
+
+
+def test_valid_config_returns_lab_and_token(tmp_path: Path) -> None:
+    path = _write(tmp_path, "lab_id: MyLab\nhuggingface_token: hf_abc\n")
+    assert read_contributor_config(path) == ("MyLab", "hf_abc")
+
+
+def test_blank_lab_id_gives_clear_error(tmp_path: Path) -> None:
+    # `lab_id:` parses to None; must not crash with `None.strip()` (the original #20 bug).
+    path = _write(tmp_path, "lab_id:\nhuggingface_token:\n")
+    with pytest.raises(RuntimeError, match="lab_id is not set"):
+        read_contributor_config(path)
+
+
+def test_placeholder_lab_id_rejected(tmp_path: Path) -> None:
+    path = _write(tmp_path, "lab_id: your_lab_id\n")
+    with pytest.raises(RuntimeError, match="placeholder"):
+        read_contributor_config(path)
+
+
+def test_missing_file_gives_clear_error(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="not found"):
+        read_contributor_config(tmp_path / "does_not_exist.yaml")

--- a/oopsie_tools/test/test_diversity.py
+++ b/oopsie_tools/test/test_diversity.py
@@ -1,0 +1,33 @@
+"""Tests for the attr-only diversity heuristics (issue #40)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+
+from oopsie_tools.test.fixtures.make_valid import write_valid_episode
+from oopsie_tools.utils.validation.diversity import check_diversity
+
+
+def test_below_min_episodes_no_warning(tmp_path: Path) -> None:
+    for i in range(3):
+        write_valid_episode(tmp_path, stem=f"ep{i}")
+    assert check_diversity(str(tmp_path)) == []
+
+
+def test_identical_instructions_warns(tmp_path: Path) -> None:
+    # write_valid_episode uses a single fixed language_instruction for every episode.
+    for i in range(6):
+        write_valid_episode(tmp_path, stem=f"ep{i}")
+    warnings = check_diversity(str(tmp_path))
+    assert any("task diversity" in w.lower() for w in warnings)
+
+
+def test_diverse_instructions_no_task_warning(tmp_path: Path) -> None:
+    for i in range(6):
+        h5_path = write_valid_episode(tmp_path, stem=f"ep{i}")
+        with h5py.File(h5_path, "r+") as f:
+            f.attrs["language_instruction"] = f"task number {i}"
+    warnings = check_diversity(str(tmp_path))
+    assert not any("task diversity" in w.lower() for w in warnings)

--- a/oopsie_tools/test/test_validate.py
+++ b/oopsie_tools/test/test_validate.py
@@ -248,3 +248,27 @@ class TestValidateSessionDir:
         write_valid_episode(tmp_path, "ep_a")
         write_valid_episode(tmp_path, "ep_b")
         assert validate_session_dir(str(tmp_path)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Better error messaging (#21)
+# ---------------------------------------------------------------------------
+
+
+class TestBetterErrors:
+    def test_validate_accepts_log_path(self, valid_success_episode, tmp_path):
+        # Regression: upload.py passes log_path to validate_h5_file for single files.
+        log_path = tmp_path / "validate.log"
+        assert validate_h5_file(str(valid_success_episode), log_path=str(log_path)) is True
+
+    def test_robot_state_joint_dof_message(self, invalid_fixtures):
+        with pytest.raises(
+            AssertionError, match="robot_state_joint_names count does not match"
+        ):
+            validate_h5_file(str(invalid_fixtures["invalid_joint_names_length_mismatch"]))
+
+    def test_action_joint_dof_message(self, invalid_fixtures):
+        with pytest.raises(
+            AssertionError, match="action_joint_names count does not match"
+        ):
+            validate_h5_file(str(invalid_fixtures["invalid_action_names_length_mismatch"]))

--- a/oopsie_tools/utils/contributor_config.py
+++ b/oopsie_tools/utils/contributor_config.py
@@ -1,0 +1,60 @@
+"""Read the contributor config (lab_id + HuggingFace token) with clear errors.
+
+Shared by the episode recorder, the upload pipeline, and the repo-stats script so a
+missing/blank config gives one actionable message instead of a cryptic crash.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_CONFIG_PATH = _REPO_ROOT / "configs" / "contributor_config.yaml"
+
+_REGISTER_HINT = (
+    "Register at https://forms.gle/9arwZHAvRjvbozoT7 to obtain your lab_id and "
+    "HuggingFace token, then set them in configs/contributor_config.yaml:\n"
+    "    lab_id: <YOUR_LAB_ID>\n"
+    "    huggingface_token: <YOUR_HF_TOKEN>\n"
+    "Use the exact lab_id you were given (capitalization matters)."
+)
+
+
+def read_contributor_config(config_path: Path | str | None = None) -> tuple[str, str]:
+    """Return ``(lab_id, huggingface_token)`` from the contributor config.
+
+    Args:
+        config_path: Optional override for the config location.
+
+    Returns:
+        A ``(lab_id, huggingface_token)`` tuple; the token may be empty.
+
+    Raises:
+        RuntimeError: If the file is missing/unparseable, or ``lab_id`` is unset or
+            still the placeholder — always with an actionable message.
+    """
+    path = Path(config_path) if config_path is not None else _DEFAULT_CONFIG_PATH
+    if not path.exists():
+        raise RuntimeError(f"Contributor config not found at {path}.\n{_REGISTER_HINT}")
+
+    try:
+        config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        raise RuntimeError(f"Could not parse {path}: {e}\n{_REGISTER_HINT}")
+    if not isinstance(config, dict):
+        config = {}
+
+    # ``config.get("lab_id", "")`` returns None when the key is present but blank
+    # (``lab_id:``), which used to crash with ``None.strip()`` — normalize first.
+    lab_id = str(config.get("lab_id") or "").strip()
+    huggingface_token = str(config.get("huggingface_token") or "").strip()
+
+    if not lab_id:
+        raise RuntimeError(f"lab_id is not set in {path}.\n{_REGISTER_HINT}")
+    if lab_id == "your_lab_id":
+        raise RuntimeError(
+            f"lab_id in {path} is still the placeholder 'your_lab_id'.\n{_REGISTER_HINT}"
+        )
+    return lab_id, huggingface_token

--- a/oopsie_tools/utils/validation/diversity.py
+++ b/oopsie_tools/utils/validation/diversity.py
@@ -1,0 +1,89 @@
+"""Lightweight, attribute-only diversity heuristics for a dataset (issue #40).
+
+Warns (never blocks by default) when a dataset shows very low task or annotation
+diversity — a nudge to catch copy-pasted annotations or an inattentive annotator.
+Reads only HDF5 attrs (never opens videos or decodes arrays) so it is cheap to run
+over a whole session directory, and it never raises.
+"""
+
+from __future__ import annotations
+
+import glob
+import logging
+import os
+from collections import Counter
+from typing import Any
+
+import h5py
+
+logger = logging.getLogger(__name__)
+
+# Below this many episodes the ratios are too noisy to be meaningful.
+MIN_EPISODES_FOR_CHECK = 5
+# A single description accounting for more than this fraction looks copy-pasted.
+DUP_DESCRIPTION_FRACTION = 0.8
+
+
+def check_diversity(samples_dir: str) -> list[str]:
+    """Return (and WARN-log) low-diversity messages for a session directory.
+
+    Args:
+        samples_dir: Directory containing ``*.h5`` / ``*.hdf5`` episodes.
+
+    Returns:
+        A list of human-readable warning strings (empty if nothing notable).
+    """
+    files = glob.glob(os.path.join(samples_dir, "**", "*.h5"), recursive=True)
+    files += glob.glob(os.path.join(samples_dir, "**", "*.hdf5"), recursive=True)
+    if len(files) < MIN_EPISODES_FOR_CHECK:
+        return []
+
+    instructions: list[str] = []
+    descriptions: list[str] = []
+    for path in files:
+        try:
+            with h5py.File(path, "r") as f:
+                instructions.append(_attr_str(f, "language_instruction"))
+                ea = f.get("episode_annotations")
+                if isinstance(ea, h5py.Group):
+                    for name in ea.keys():
+                        sub = ea[name]
+                        if not isinstance(sub, h5py.Group):
+                            continue
+                        desc = _attr_str(sub, "failure_description").lower()
+                        if desc:
+                            descriptions.append(desc)
+        except Exception:
+            continue
+
+    warnings: list[str] = []
+    n = len(instructions)
+    distinct_instructions = len({i for i in instructions if i})
+    if n >= MIN_EPISODES_FOR_CHECK and distinct_instructions <= 1:
+        warnings.append(
+            f"Low task diversity: all {n} episodes share a single language_instruction."
+        )
+    elif n >= 10 and distinct_instructions / n < 0.1:
+        warnings.append(
+            f"Low task diversity: only {distinct_instructions} distinct instruction(s) "
+            f"across {n} episodes."
+        )
+
+    if len(descriptions) >= MIN_EPISODES_FOR_CHECK:
+        top_desc, top_n = Counter(descriptions).most_common(1)[0]
+        if top_n / len(descriptions) > DUP_DESCRIPTION_FRACTION:
+            warnings.append(
+                f"Possible copied annotations: {top_n}/{len(descriptions)} failure "
+                f'descriptions are identical ("{top_desc[:60]}...").'
+            )
+
+    for w in warnings:
+        logger.warning("[diversity] %s", w)
+    return warnings
+
+
+def _attr_str(group: h5py.Group | h5py.File, key: str) -> str:
+    value: Any = group.attrs.get(key, "")
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    return str(value).strip()

--- a/oopsie_tools/utils/validation/episode_validator.py
+++ b/oopsie_tools/utils/validation/episode_validator.py
@@ -57,7 +57,7 @@ def _validate_profile_consistency(data: EpisodeData) -> None:
     assert profile is not None
 
     for key in profile.robot_state_keys:
-        assert key in data.observations, f"Missing observations key required by profile: {key}. Got {list(data.observations['robot_states'].keys())}, required by profile.robot_state_keys={profile.robot_state_keys}"
+        assert key in data.observations, f"Missing observations key required by profile: {key}. Got {list(data.observations.keys())}, required by profile.robot_state_keys={profile.robot_state_keys}"
 
     for key in profile.action_space:
         assert key in data.actions, (
@@ -71,7 +71,10 @@ def _validate_profile_consistency(data: EpisodeData) -> None:
     if jp_obs is not None and jp_obs.ndim >= 2:
         assert len(profile.robot_state_joint_names) == jp_obs.shape[-1], (
             "robot_state_joint_names count does not match observations/joint_position DOF: "
-            f"expected {jp_obs.shape[-1]}, got {len(profile.robot_state_joint_names)}"
+            f"the robot profile lists {len(profile.robot_state_joint_names)} joint name(s) in "
+            f"robot_state_joint_names, but the recorded observations/joint_position has "
+            f"{jp_obs.shape[-1]} DOF (last axis). Fix robot_state_joint_names in the robot "
+            "profile (or the recorded joint_position) so the two counts match."
         )
 
     if profile.action_joint_names:
@@ -80,7 +83,10 @@ def _validate_profile_consistency(data: EpisodeData) -> None:
             if arr is not None and arr.ndim >= 2:
                 assert len(profile.action_joint_names) == arr.shape[-1], (
                     f"action_joint_names count does not match actions/{key} DOF: "
-                    f"expected {arr.shape[-1]}, got {len(profile.action_joint_names)}"
+                    f"the robot profile lists {len(profile.action_joint_names)} joint name(s) in "
+                    f"action_joint_names, but the recorded actions/{key} has {arr.shape[-1]} DOF "
+                    "(last axis). Fix action_joint_names in the robot profile (or the recorded "
+                    "actions) so the two counts match."
                 )
 
 

--- a/oopsie_tools/utils/validation/validation_utils.py
+++ b/oopsie_tools/utils/validation/validation_utils.py
@@ -19,12 +19,17 @@ from oopsie_tools.utils.validation.episode_validator import validate_episode
 logger = logging.getLogger(__name__)
 
 
-def validate_h5_file(h5_path: str, strict_annotation_check: bool = False) -> bool:
+def validate_h5_file(
+    h5_path: str,
+    strict_annotation_check: bool = False,
+    log_path: str | Path | None = None,
+) -> bool:
     """Validate a single HDF5 episode file.
 
     Args:
         h5_path: Path to the .h5 file.
         strict_annotation_check: If True, require that annotations are present and non-empty.
+        log_path: Optional file to also write log output to (mirrors ``validate_session_dir``).
 
     Returns:
         True if all checks pass.
@@ -32,6 +37,8 @@ def validate_h5_file(h5_path: str, strict_annotation_check: bool = False) -> boo
     Raises:
         AssertionError: On the first validation failure.
     """
+    if log_path is not None:
+        setup_logger(__name__, log_path)
     data = load_episode_from_h5(h5_path)
     validate_episode(data, strict_annotation_check=strict_annotation_check)
     return True

--- a/scripts/validate_and_upload/query_submissions.py
+++ b/scripts/validate_and_upload/query_submissions.py
@@ -1,0 +1,74 @@
+"""Query your lab's OopsieData submissions repo on HuggingFace for quick stats.
+
+Lets a lab confirm what has actually landed in ``OopsieData-Submissions/<lab_id>``
+without downloading anything.
+
+Usage:
+    python scripts/validate_and_upload/query_submissions.py
+    python scripts/validate_and_upload/query_submissions.py --lab-id SomeOtherLab
+
+Environment:
+    HF_TOKEN  — override the config token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from collections import Counter
+
+from oopsie_tools.utils.contributor_config import read_contributor_config
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Query your lab's OopsieData submissions repo for episode counts/stats",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--lab-id",
+        default=None,
+        help="Lab id to query (default: lab_id from configs/contributor_config.yaml)",
+    )
+    args = parser.parse_args()
+
+    config_lab_id, config_token = read_contributor_config()
+    lab_id = args.lab_id.strip() if args.lab_id else config_lab_id
+    hf_token = os.environ.get("HF_TOKEN", "").strip() or config_token
+
+    from huggingface_hub import HfApi
+
+    repo = f"OopsieData-Submissions/{lab_id}"
+    api = HfApi(token=hf_token or None)
+
+    try:
+        api.repo_info(repo_id=repo, repo_type="dataset")
+    except Exception:
+        logger.info("No submissions repo found yet at https://huggingface.co/datasets/%s", repo)
+        logger.info("(It is created automatically on your first successful upload.)")
+        return 0
+
+    files = api.list_repo_files(repo_id=repo, repo_type="dataset")
+    h5 = [f for f in files if f.endswith(".h5") or f.endswith(".hdf5")]
+    mp4 = [f for f in files if f.endswith(".mp4")]
+    by_dir = Counter(f.split("/")[0] if "/" in f else "(root)" for f in h5)
+
+    logger.info("Repo:           https://huggingface.co/datasets/%s", repo)
+    logger.info("Episodes (.h5): %d", len(h5))
+    logger.info("Videos (.mp4):  %d", len(mp4))
+    logger.info("Total files:    %d", len(files))
+    if by_dir:
+        logger.info("Episodes by top-level folder:")
+        for name, count in sorted(by_dir.items()):
+            logger.info("  %-32s %d", name, count)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_and_upload/upload.py
+++ b/scripts/validate_and_upload/upload.py
@@ -18,42 +18,30 @@ from __future__ import annotations
 
 import logging
 import sys
-import yaml
 import os
 import argparse
 from pathlib import Path
+from oopsie_tools.utils.contributor_config import read_contributor_config
+from oopsie_tools.utils.log import setup_logger
+from oopsie_tools.utils.validation.diversity import check_diversity
 from oopsie_tools.utils.validation.validation_utils import validate_h5_file, validate_session_dir
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
-# ── Config ────────────────────────────────────────────────────────────────────
-
-# Read lab_id from configs/contributor_config.yaml
-try:
-    config_path = (
-        Path(__file__).resolve().parent.parent.parent
-        / "configs"
-        / "contributor_config.yaml"
-    )
-    with open(config_path, "r") as f:
-        config = yaml.safe_load(f)
-        lab_id = config.get("lab_id", "").strip()
-        huggingface_token = config.get("huggingface_token", "").strip()
-        if not lab_id:
-            raise ValueError(
-                "lab_id must be set in configs/contributor_config.yaml"
-            )
-except Exception as e:
-    raise RuntimeError(
-        f"Could not read lab_id from configs/contributor_config.yaml: {e}"
-    )
-
-LAB_ID = lab_id
-HF_TOKEN = huggingface_token
-HF_REPO = f"OopsieData-Submissions/{LAB_ID}"
-
 # ── Step 1: HuggingFace authentication ────────────────────────────────────────
+
+
+def _resolve_hf_target() -> tuple[str, str]:
+    """Resolve ``(hf_token, repo_id)`` lazily.
+
+    Read only when actually uploading so validation, ``--skip_upload`` and ``--help``
+    work on a fresh checkout without a filled-in contributor config. ``HF_TOKEN`` in the
+    environment overrides the config token (as documented in the module docstring).
+    """
+    lab_id, config_token = read_contributor_config()
+    token = os.environ.get("HF_TOKEN", "").strip() or config_token
+    return token, f"OopsieData-Submissions/{lab_id}"
 
 
 def hf_login(token: str):
@@ -75,6 +63,10 @@ def _validate_import_path():
 
 
 def run_validation(base_path: str, episode_id: str, log_path: str | None=None) -> bool:
+    # Route this module's pass/fail lines to the log file too, so --log-path captures
+    # the single-file path (validate_session_dir already logs through its own logger).
+    if log_path is not None:
+        setup_logger(__name__, log_path)
     target = os.path.join(base_path, f"{episode_id}.h5") if episode_id else base_path
     if os.path.isfile(target):
         try:
@@ -95,17 +87,14 @@ def run_validation(base_path: str, episode_id: str, log_path: str | None=None) -
 # ── Step 3: create repo (if needed) ───────────────────────────────────────────
 
 
-def ensure_repo():
-    from huggingface_hub import HfApi
-
-    api = HfApi(token=HF_TOKEN)
+def ensure_repo(api, repo: str):
     try:
-        api.repo_info(repo_id=HF_REPO, repo_type="dataset")
-        logger.info("[hf]    Repo already exists: https://huggingface.co/datasets/%s", HF_REPO)
+        api.repo_info(repo_id=repo, repo_type="dataset")
+        logger.info("[hf]    Repo already exists: https://huggingface.co/datasets/%s", repo)
     except Exception:
-        logger.info("[hf]    Creating repo: %s", HF_REPO)
-        api.create_repo(repo_id=HF_REPO, repo_type="dataset", private=False)
-        logger.info("[hf]    Created: https://huggingface.co/datasets/%s", HF_REPO)
+        logger.info("[hf]    Creating repo: %s", repo)
+        api.create_repo(repo_id=repo, repo_type="dataset", private=False)
+        logger.info("[hf]    Created: https://huggingface.co/datasets/%s", repo)
 
 
 # ── Step 4: upload ────────────────────────────────────────────────────────────
@@ -138,12 +127,8 @@ def check_folder_size(samples_dir: str) -> None:
     sys.exit(1)
 
 
-def upload_dataset(samples_dir: str, commit_message: str):
-    from huggingface_hub import HfApi
-
-    api = HfApi(token=HF_TOKEN)
-
-    logger.info("[upload] Uploading %s → %s", samples_dir, HF_REPO)
+def upload_dataset(api, repo: str, samples_dir: str):
+    logger.info("[upload] Uploading %s → %s", samples_dir, repo)
     logger.info("[upload] Files to upload:")
     total_bytes = 0
     for root, _, files in os.walk(samples_dir):
@@ -159,12 +144,34 @@ def upload_dataset(samples_dir: str, commit_message: str):
 
     api.upload_large_folder(
         folder_path=samples_dir,
-        repo_id=HF_REPO,
+        repo_id=repo,
         repo_type="dataset",
     )
 
     logger.info("[upload] Done!")
-    logger.info("[upload] Dataset URL: https://huggingface.co/datasets/%s", HF_REPO)
+    logger.info("[upload] Dataset URL: https://huggingface.co/datasets/%s", repo)
+
+    # Post-upload confirmation: read the repo back so the user sees their data landed.
+    try:
+        remote_h5 = [
+            f for f in api.list_repo_files(repo_id=repo, repo_type="dataset")
+            if f.endswith(".h5")
+        ]
+        local_h5 = sum(
+            1 for _r, _d, files in os.walk(samples_dir) for fn in files if fn.endswith(".h5")
+        )
+        logger.info(
+            "[upload] Confirmed: %d episode(s) now in the repo (from %d local .h5).",
+            len(remote_h5), local_h5,
+        )
+        if local_h5 and len(remote_h5) < local_h5:
+            logger.warning(
+                "[upload] Remote episode count (%d) is below local (%d) — "
+                "re-run the upload if this is unexpected.",
+                len(remote_h5), local_h5,
+            )
+    except Exception as e:
+        logger.warning("[upload] Could not confirm upload via repo listing: %s", e)
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
@@ -202,21 +209,18 @@ def main():
         default=None,
         help="Path to log file"
     )
+    parser.add_argument(
+        "--strict-diversity",
+        action="store_true",
+        help="Treat low task/annotation diversity warnings as a hard error (non-zero exit)",
+    )
     args = parser.parse_args()
 
     logger.info("=" * 60)
     logger.info("  Robotic Failure Dataset — End-to-End Upload Pipeline")
     logger.info("=" * 60)
 
-    # 1. Auth
-    hf_login(HF_TOKEN)
-
     samples_dir = os.path.abspath(os.path.normpath(args.path))
-    if args.episode_id is None:
-        dir_name = os.path.basename(samples_dir.rstrip(os.sep)) or samples_dir
-        commit_message = f"Add {dir_name}"
-    else:
-        commit_message = f"Add episode {args.episode_id}"
 
     # 2. Pre-upload folder-size check
     if not args.skip_upload:
@@ -231,10 +235,22 @@ def main():
     else:
         logger.info("[validate] Skipped.")
 
-    # 4 + 5. Create repo and upload
+    # 3b. Low-diversity warning (advisory unless --strict-diversity). Reads attrs only.
+    diversity_warnings = check_diversity(samples_dir)
+    if diversity_warnings and args.strict_diversity:
+        logger.error("Aborting: low-diversity warnings present and --strict-diversity is set.")
+        sys.exit(1)
+
+    # 4 + 5. Authenticate, create repo, and upload (config + auth only needed to upload,
+    # so validation / --skip_upload / --help work without a filled-in contributor config).
     if not args.skip_upload:
-        ensure_repo()
-        upload_dataset(samples_dir, commit_message)
+        from huggingface_hub import HfApi
+
+        hf_token, hf_repo = _resolve_hf_target()
+        hf_login(hf_token)
+        api = HfApi(token=hf_token)
+        ensure_repo(api, hf_repo)
+        upload_dataset(api, hf_repo, samples_dir)
     else:
         logger.info("[upload] Skipped (--skip_upload).")
 


### PR DESCRIPTION
> Backend-only, branched off `main` — **independent of the annotator UI stack (#41–#45)**, so it
> can be reviewed/merged in parallel.

## Summary

Developer-experience fixes for the validate → upload pipeline.

- **#20 — `lab_id` errors.** New `oopsie_tools/utils/contributor_config.read_contributor_config`
  reads the config None-safely and raises **one clear, actionable error** (with the registration
  hint) when `lab_id` is blank (`lab_id:`), missing, or still the placeholder — instead of the
  cryptic `'NoneType' object has no attribute 'strip'` crash. Used by `EpisodeRecorder` and
  `upload.py`, and read **lazily** (only when uploading) so validation / `--skip_upload` / `--help`
  work on a fresh checkout. A conftest fixture supplies a test lab_id so **the test suite runs green
  on a fresh checkout** (previously 40 tests failed on the empty committed config). AI_CONTEXT note added.
- **#21 — clearer validation errors.** `validate_h5_file` now accepts `log_path` (fixes a
  `TypeError` on the single-episode upload path); fixed a latent `KeyError` that masked the
  "missing observations key" message; and reworded the DOF/joint-name mismatch messages to name
  both sides ("the profile lists N … but the recorded array has M DOF …").
- **#37 — upload confirmation + repo stats.** After upload the repo is listed back to confirm the
  episode count (with a mismatch warning); new `scripts/validate_and_upload/query_submissions.py`
  lets a lab query its own `OopsieData-Submissions/<lab_id>` repo for counts anytime. `hf_login`
  now runs only when actually uploading, and the documented `HF_TOKEN` env override is honored.
- **#40 — low-diversity warning.** New `check_diversity` (attrs-only, never raises) warns at upload
  time about single-instruction datasets or copy-pasted failure descriptions; `--strict-diversity`
  turns warnings into a non-zero exit.

## ⚠️ One behavior note
`--skip_upload` (and `--help`) now work **without** a filled-in contributor config, and `hf_login`
only happens when uploading — so contributors can validate their data offline before registering.

## How to verify

```bash
# #20: a blank lab_id gives a clear message (not None.strip); the suite is green on a fresh checkout
uv run pytest oopsie_tools/test/          # green apart from one sandbox-only path-permission test

# #21 + #40: validate offline (no HF auth needed) and see diversity warnings
uv run python scripts/validate_and_upload/upload.py --path <samples-dir> --skip_upload
uv run python scripts/validate_and_upload/upload.py --path <samples-dir> --episode_id 000001 --skip_upload   # no TypeError
uv run python scripts/validate_and_upload/upload.py --path <samples-dir> --skip_upload --strict-diversity     # non-zero exit if low diversity

# #37: query your lab's submissions repo (needs your real lab_id + token in configs/contributor_config.yaml)
uv run python scripts/validate_and_upload/query_submissions.py
```
- **#20:** with `lab_id:` blank in `configs/contributor_config.yaml`, `upload.py … --skip_upload`
  validates fine; only an actual upload asks for a real lab_id, and then the error (if unset) points
  to the registration form.
- **#21:** a robot profile whose `robot_state_joint_names`/`action_joint_names` count doesn't match
  the recorded DOF prints an explanatory message; single-episode validation + `--log-path` works and
  writes a non-empty log.
- **#40:** a folder of episodes with one repeated instruction / identical failure descriptions emits
  `[diversity]` warnings.

Closes #20
Closes #21
Closes #37
Closes #40
