### PR TITLE
install-skill for all agents

### DIFF
--- a/oopsie_data_tools/cli.py
+++ b/oopsie_data_tools/cli.py
@@ -25,7 +25,7 @@ import click
 
 # Imported eagerly, unlike the heavier command modules below: the parser needs the agent
 # names to build --agent's choices, and this module costs nothing but the standard library.
-from oopsie_data_tools.utils.claude_skill import AGENT_SKILL_DIRS as _AGENT_CHOICES
+from oopsie_data_tools.utils.claude_skill import AGENT_CHOICES as _AGENT_CHOICES
 from oopsie_data_tools.utils.claude_skill import DEFAULT_AGENT as _DEFAULT_AGENT
 from oopsie_data_tools.utils.hf_limits import BATCH_SIZE, FILE_LIMIT
 from oopsie_data_tools.utils.paths import ENV_CONFIG_DIR
@@ -780,6 +780,7 @@ restructure.help = restructure.help.format(limit=FILE_LIMIT, batch=BATCH_SIZE)
     default=_DEFAULT_AGENT,
     help=(
         f"Which agent's skills directory to install into (default: {_DEFAULT_AGENT}). "
+        "'all' installs for Claude Code, Cursor, and Codex; "
         "'agents' is the vendor-neutral .agents/skills/; 'none' writes a plain ./skills/ "
         "that no agent scans, for copying onward yourself"
     ),
@@ -788,7 +789,6 @@ restructure.help = restructure.help.format(limit=FILE_LIMIT, batch=BATCH_SIZE)
     "--user", is_flag=True,
     help="Install under your home directory instead of the working directory",
 )
-@click.option("--force", is_flag=True, help="Overwrite an existing installation of the skill")
 @click.option(
     "--check",
     is_flag=True,
@@ -797,20 +797,23 @@ restructure.help = restructure.help.format(limit=FILE_LIMIT, batch=BATCH_SIZE)
         "instead of installing anything. Exits 1 if any copy is stale or missing"
     ),
 )
-def install_skill_cmd(agent, user, force, check):
+def install_skill_cmd(agent, user, check):
     """Install the bundled agent skill for oopsie-data.
 
     Copy the skill that ships with this package into a directory your coding agent scans, so
     it knows how to drive the contributor workflow. SKILL.md is a shared format, so the same
-    payload works for Claude Code, Cursor, Codex and anything else that reads it — --agent
-    only chooses the destination. Defaults to ./.claude/skills/oopsie-data/, which Claude
-    Code and Cursor both read; --user installs into your home directory instead. Entirely
-    optional: nothing else in oopsie-data needs an agent, and no files are written anywhere
-    unless you run this command.
+    payload works for Claude Code, Cursor, Codex and anything else that reads it. Pass
+    --agent all to install for all three supported agents in one pass, or select one agent's
+    destination. Defaults to ./.claude/skills/oopsie-data/, which Claude Code and Cursor
+    both read; --user installs under your home directory instead. Entirely optional: nothing
+    else in oopsie-data needs an agent, and no files are written anywhere unless you run
+    this command.
 
     \b
     Examples:
       oopsie-data install-skill
+      oopsie-data install-skill --agent all
+      oopsie-data install-skill --agent all --user  # all agents, every project
       oopsie-data install-skill --user             # available in every project
       oopsie-data install-skill --agent cursor
       oopsie-data install-skill --agent none       # a plain ./skills/ to copy onward
@@ -820,7 +823,7 @@ def install_skill_cmd(agent, user, force, check):
 
     if check:
         return check_installations()
-    return install_skill(user=user, force=force, agent=agent)
+    return install_skill(user=user, agent=agent)
 
 
 # ── entry point ───────────────────────────────────────────────────────────────

--- a/oopsie_data_tools/test/test_install_skill.py
+++ b/oopsie_data_tools/test/test_install_skill.py
@@ -1,8 +1,8 @@
 """Tests for ``oopsie-data install-skill``.
 
 The command is a directory copy, so what is worth pinning down is the destination for
-each scope, that an existing directory is never clobbered without --force, and that the
-payload really is inside the package rather than only in a source checkout.
+each scope, replacement of an older installed copy, and that the payload really is inside
+the package rather than only in a source checkout.
 """
 
 from __future__ import annotations
@@ -67,7 +67,7 @@ def test_default_install_lands_where_an_agent_actually_scans(home, tmp_path):
     [
         ("claude", ".claude/skills"),
         ("cursor", ".cursor/skills"),
-        ("codex", ".codex/skills"),
+        ("codex", ".agents/skills"),
         ("agents", ".agents/skills"),
         ("none", "skills"),
     ],
@@ -76,6 +76,36 @@ def test_agent_selects_the_destination(home, tmp_path, agent, subdir):
     assert cli.main(["install-skill", "--agent", agent]) == 0
 
     assert (tmp_path / "project" / subdir / "oopsie-data" / "SKILL.md").is_file()
+
+
+def test_all_installs_for_claude_cursor_and_codex(home, tmp_path):
+    assert cli.main(["install-skill", "--agent", "all"]) == 0
+
+    project = tmp_path / "project"
+    for subdir in (".claude/skills", ".cursor/skills", ".agents/skills"):
+        assert (project / subdir / "oopsie-data" / "SKILL.md").is_file()
+    assert not (project / ".codex").exists()
+
+
+def test_all_user_scope_installs_every_copy_under_home(home, tmp_path):
+    assert cli.main(["install-skill", "--agent", "all", "--user"]) == 0
+
+    for subdir in (".claude/skills", ".cursor/skills", ".agents/skills"):
+        assert (home / subdir / "oopsie-data" / "SKILL.md").is_file()
+    assert not (tmp_path / "project" / ".claude").exists()
+
+
+def test_all_replaces_existing_copy_and_installs_the_other_destinations(home, tmp_path):
+    claude = tmp_path / "project" / ".claude" / "skills" / "oopsie-data"
+    claude.mkdir(parents=True)
+    (claude / "SKILL.md").write_text("local edits", encoding="utf-8")
+
+    assert cli.main(["install-skill", "--agent", "all"]) == 0
+
+    assert (claude / "SKILL.md").read_text(encoding="utf-8") != "local edits"
+    project = tmp_path / "project"
+    assert (project / ".cursor" / "skills" / "oopsie-data" / "SKILL.md").is_file()
+    assert (project / ".agents" / "skills" / "oopsie-data" / "SKILL.md").is_file()
 
 
 def test_install_copies_the_whole_payload_tree(home, tmp_path):
@@ -98,23 +128,14 @@ def test_user_scope_installs_into_the_home_directory(home, tmp_path):
     assert not (tmp_path / "project" / ".claude").exists()
 
 
-def test_refuses_to_overwrite_without_force(home, tmp_path):
-    assert cli.main(["install-skill"]) == 0
-    edited = tmp_path / "project" / ".claude" / "skills" / "oopsie-data" / "SKILL.md"
-    edited.write_text("local edits", encoding="utf-8")
-
-    assert cli.main(["install-skill"]) == 1
-    assert edited.read_text(encoding="utf-8") == "local edits"
-
-
-def test_force_replaces_the_existing_installation(home, tmp_path):
+def test_reinstall_replaces_the_existing_installation(home, tmp_path):
     assert cli.main(["install-skill"]) == 0
     installed = tmp_path / "project" / ".claude" / "skills" / "oopsie-data"
     (installed / "SKILL.md").write_text("local edits", encoding="utf-8")
     stale = installed / "stale.md"
-    stale.write_text("removed by --force", encoding="utf-8")
+    stale.write_text("removed on reinstall", encoding="utf-8")
 
-    assert cli.main(["install-skill", "--force"]) == 0
+    assert cli.main(["install-skill"]) == 0
 
     assert "local edits" not in (installed / "SKILL.md").read_text(encoding="utf-8")
     assert not stale.exists()

--- a/oopsie_data_tools/utils/claude_skill.py
+++ b/oopsie_data_tools/utils/claude_skill.py
@@ -4,10 +4,11 @@ Agents discover skills by scanning the filesystem for ``<dir>/SKILL.md``, so "in
 one is a directory copy — no agent CLI, and no network access, is involved.
 
 ``--agent`` picks that directory and defaults to Claude Code's, because a skill that lands
-somewhere nothing scans is not installed in any useful sense. ``--agent agents`` writes the
-vendor-neutral ``.agents/skills/`` and ``--agent none`` the plain ``skills/`` directory, for
-anyone who would rather copy it onward themselves. ``--user`` swaps the working directory
-for the home directory, making the skill available in every project.
+somewhere nothing scans is not installed in any useful sense. ``--agent all`` installs for
+Claude Code, Cursor, and Codex in one pass; ``--agent agents`` writes the vendor-neutral
+``.agents/skills/`` and ``--agent none`` the plain ``skills/`` directory, for anyone who
+would rather copy it onward themselves. ``--user`` swaps the working directory for the home
+directory, making the skill available in every project.
 
 Installing is an explicit opt-in subcommand rather than anything that runs at install time:
 contributors who do not use an agent never have files written for them at all.
@@ -34,12 +35,16 @@ VERSION_STAMP = ".skill-version"
 AGENT_SKILL_DIRS: dict[str, tuple[str, str]] = {
     "claude": ("Claude Code", ".claude/skills"),
     "cursor": ("Cursor", ".cursor/skills"),
-    "codex": ("Codex", ".codex/skills"),
+    # Codex follows the shared Agent Skills convention rather than using .codex/skills.
+    "codex": ("Codex", ".agents/skills"),
     "agents": ("any agent following the convention", ".agents/skills"),
     "none": ("a plain directory, scanned by nothing", "skills"),
 }
 
 DEFAULT_AGENT = "claude"
+ALL_AGENT = "all"
+AGENT_CHOICES = (*AGENT_SKILL_DIRS, ALL_AGENT)
+_ALL_AGENT_TARGETS = ("claude", "cursor", "codex")
 
 
 def bundled_skill_dir() -> Path:
@@ -65,10 +70,28 @@ def skill_destination(
     user: bool = False, agent: str = DEFAULT_AGENT, root: Path | None = None
 ) -> Path:
     """Where the skill would be installed for the given scope and agent."""
+    destinations = skill_destinations(user=user, agent=agent, root=root)
+    if len(destinations) != 1:
+        raise ValueError(f"{agent!r} selects more than one skill destination")
+    return destinations[0]
+
+
+def skill_destinations(
+    user: bool = False, agent: str = DEFAULT_AGENT, root: Path | None = None
+) -> list[Path]:
+    """Every destination selected for the given scope and agent."""
     if root is not None:
-        return root / SKILL_NAME
+        return [root / SKILL_NAME]
+
     base = Path.home() if user else Path.cwd()
-    return base / AGENT_SKILL_DIRS[agent][1] / SKILL_NAME
+    selected = _ALL_AGENT_TARGETS if agent == ALL_AGENT else (agent,)
+    destinations = []
+    for key in selected:
+        destination = base / AGENT_SKILL_DIRS[key][1] / SKILL_NAME
+        # Codex and the vendor-neutral target intentionally resolve to the same directory.
+        if destination not in destinations:
+            destinations.append(destination)
+    return destinations
 
 
 def installed_version(dest: Path) -> str | None:
@@ -121,7 +144,7 @@ def check_installations() -> int:
 
     if stale:
         logger.info(
-            "\nRe-install the copies above with 'oopsie-data install-skill --force' "
+            "\nRe-install the copies above with 'oopsie-data install-skill' "
             "(add --agent/--user to match where each one lives)."
         )
     return 1 if stale else 0
@@ -129,7 +152,6 @@ def check_installations() -> int:
 
 def install_skill(
     user: bool = False,
-    force: bool = False,
     agent: str = DEFAULT_AGENT,
     root: Path | None = None,
 ) -> int:
@@ -138,23 +160,24 @@ def install_skill(
         logger.error("The installed package does not contain a skill payload at %s.", source)
         return 1
 
-    dest = skill_destination(user, agent, root)
-    if dest.exists():
-        if not force:
-            logger.error(
-                "%s already exists. Pass --force to overwrite it.\n"
-                "Anything you added inside that directory would be lost, so it is not "
-                "overwritten by default.",
-                dest,
-            )
-            return 1
-        shutil.rmtree(dest)
+    destinations = skill_destinations(user, agent, root)
+    package_version = _package_version()
+    for dest in destinations:
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(source, dest)
+        (dest / VERSION_STAMP).write_text(package_version + "\n", encoding="utf-8")
+        logger.info("Installed the '%s' skill to %s", SKILL_NAME, dest)
 
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(source, dest)
-    (dest / VERSION_STAMP).write_text(_package_version() + "\n", encoding="utf-8")
-
-    logger.info("Installed the '%s' skill to %s", SKILL_NAME, dest)
+    if agent == ALL_AGENT:
+        scope = "in every project" if user else "in this project"
+        logger.info(
+            "Claude Code, Cursor, and Codex pick up these copies %s. Start a new agent "
+            "session to use the skill.",
+            scope,
+        )
+        return 0
 
     if agent == "none":
         # A plain directory: visible, committable, and not tied to any one agent. No agent
@@ -165,6 +188,7 @@ def install_skill(
             for key, (label, subdir) in AGENT_SKILL_DIRS.items()
             if key != "none"
         )
+        dest = destinations[0]
         try:
             copy_from = dest.relative_to(Path.cwd())
         except ValueError:
@@ -193,6 +217,6 @@ def install_skill(
         label,
         scope,
         SKILL_NAME,
-        ",".join(key for key in AGENT_SKILL_DIRS if key != agent),
+        ",".join(key for key in AGENT_CHOICES if key != agent),
     )
     return 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI-only skill install behavior; Codex users may need to migrate from `.codex/skills`, and reinstall now silently overwrites local edits to installed skills.
> 
> **Overview**
> **`install-skill`** gains **`--agent all`**, which copies the bundled skill into Claude Code (`.claude/skills`), Cursor (`.cursor/skills`), and Codex in one run. Codex’s target moves from **`.codex/skills`** to **`.agents/skills`** (shared Agent Skills layout); **`--agent all`** deduplicates so Codex and the vendor-neutral path don’t get two copies in the same folder.
> 
> The **`--force`** flag is removed: any install **replaces** an existing skill directory (remove tree, recopy payload, refresh version stamp). **`--check`** stale guidance now says to re-run **`install-skill`** without mentioning force. CLI **`--agent`** choices come from **`AGENT_CHOICES`**, which includes **`all`**.
> 
> Tests cover the Codex path change, **`all`** (project and **`--user`** scope), and overwrite-on-reinstall instead of refuse-without-force.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd6bd301ff81305a93042cd1af865f138d38cd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->