### PR TITLE
fix agent skill locations

### DIFF
--- a/oopsie_data_tools/cli.py
+++ b/oopsie_data_tools/cli.py
@@ -25,8 +25,12 @@ import click
 
 # Imported eagerly, unlike the heavier command modules below: the parser needs the agent
 # names to build --agent's choices, and this module costs nothing but the standard library.
-from oopsie_data_tools.utils.claude_skill import AGENT_SKILL_DIRS as _AGENT_CHOICES
-from oopsie_data_tools.utils.claude_skill import DEFAULT_AGENT as _DEFAULT_AGENT
+from oopsie_data_tools.utils.agent_skill_installation import (
+    AGENT_SKILL_DIRS as _AGENT_CHOICES,
+)
+from oopsie_data_tools.utils.agent_skill_installation import (
+    DEFAULT_AGENT as _DEFAULT_AGENT,
+)
 from oopsie_data_tools.utils.hf_limits import BATCH_SIZE, FILE_LIMIT
 from oopsie_data_tools.utils.paths import ENV_CONFIG_DIR
 
@@ -817,7 +821,10 @@ def install_skill_cmd(agent, user, force, check):
       oopsie-data install-skill --agent none       # plain ./skills/
       oopsie-data install-skill --check            # is an installed copy out of date?
     """
-    from oopsie_data_tools.utils.claude_skill import check_installations, install_skill
+    from oopsie_data_tools.utils.agent_skill_installation import (
+        check_installations,
+        install_skill,
+    )
 
     if check:
         return check_installations()

--- a/oopsie_data_tools/cli.py
+++ b/oopsie_data_tools/cli.py
@@ -780,7 +780,7 @@ restructure.help = restructure.help.format(limit=FILE_LIMIT, batch=BATCH_SIZE)
     default=_DEFAULT_AGENT,
     help=(
         f"Which agent's skills directory to install into (default: {_DEFAULT_AGENT}); "
-        "'none' writes to plain ./skills/"
+        "'agents' writes to shared ./.agents/skills/; 'none' writes to plain ./skills/"
     ),
 )
 @click.option(
@@ -813,6 +813,7 @@ def install_skill_cmd(agent, user, force, check):
       oopsie-data install-skill --user             # available in every project
       oopsie-data install-skill --agent cursor
       oopsie-data install-skill --agent codex
+      oopsie-data install-skill --agent agents     # shared ./.agents/skills/
       oopsie-data install-skill --agent none       # plain ./skills/
       oopsie-data install-skill --check            # is an installed copy out of date?
     """

--- a/oopsie_data_tools/cli.py
+++ b/oopsie_data_tools/cli.py
@@ -779,9 +779,8 @@ restructure.help = restructure.help.format(limit=FILE_LIMIT, batch=BATCH_SIZE)
     type=click.Choice(list(_AGENT_CHOICES)),
     default=_DEFAULT_AGENT,
     help=(
-        f"Which agent's skills directory to install into (default: {_DEFAULT_AGENT}). "
-        "'agents' is the vendor-neutral .agents/skills/; 'none' writes a plain ./skills/ "
-        "that no agent scans, for copying onward yourself"
+        f"Which agent's skills directory to install into (default: {_DEFAULT_AGENT}); "
+        "'none' writes to plain ./skills/"
     ),
 )
 @click.option(
@@ -802,18 +801,19 @@ def install_skill_cmd(agent, user, force, check):
 
     Copy the skill that ships with this package into a directory your coding agent scans, so
     it knows how to drive the contributor workflow. SKILL.md is a shared format, so the same
-    payload works for Claude Code, Cursor, Codex and anything else that reads it — --agent
-    only chooses the destination. Defaults to ./.claude/skills/oopsie-data/, which Claude
-    Code and Cursor both read; --user installs into your home directory instead. Entirely
-    optional: nothing else in oopsie-data needs an agent, and no files are written anywhere
-    unless you run this command.
+    payload works for Claude Code, Cursor and Codex — --agent only chooses the destination.
+    Claude uses .claude/skills/; Cursor and Codex share .agents/skills/. Defaults to
+    ./.claude/skills/oopsie-data/; --user installs into your home directory instead.
+    Entirely optional: nothing else in oopsie-data needs an agent, and no files are written
+    anywhere unless you run this command.
 
     \b
     Examples:
       oopsie-data install-skill
       oopsie-data install-skill --user             # available in every project
       oopsie-data install-skill --agent cursor
-      oopsie-data install-skill --agent none       # a plain ./skills/ to copy onward
+      oopsie-data install-skill --agent codex
+      oopsie-data install-skill --agent none       # plain ./skills/
       oopsie-data install-skill --check            # is an installed copy out of date?
     """
     from oopsie_data_tools.utils.claude_skill import check_installations, install_skill

--- a/oopsie_data_tools/test/test_install_skill.py
+++ b/oopsie_data_tools/test/test_install_skill.py
@@ -68,6 +68,7 @@ def test_default_install_lands_where_an_agent_actually_scans(home, tmp_path):
         ("claude", ".claude/skills"),
         ("codex", ".agents/skills"),
         ("cursor", ".agents/skills"),
+        ("agents", ".agents/skills"),
         ("none", "skills"),
     ],
 )
@@ -78,7 +79,13 @@ def test_agent_selects_the_destination(home, tmp_path, agent, subdir):
 
 
 def test_only_supported_agent_choices_are_available():
-    assert set(claude_skill.AGENT_SKILL_DIRS) == {"claude", "codex", "cursor", "none"}
+    assert set(claude_skill.AGENT_SKILL_DIRS) == {
+        "claude",
+        "codex",
+        "cursor",
+        "agents",
+        "none",
+    }
 
 
 def test_agent_mapping_keeps_labels_and_destinations_together():
@@ -86,6 +93,7 @@ def test_agent_mapping_keeps_labels_and_destinations_together():
         "claude": ("Claude Code", ".claude/skills"),
         "codex": ("Codex", ".agents/skills"),
         "cursor": ("Cursor", ".agents/skills"),
+        "agents": ("any agent following the shared convention", ".agents/skills"),
         "none": ("a plain directory, scanned by nothing", "skills"),
     }
 
@@ -96,6 +104,7 @@ def test_agent_mapping_keeps_labels_and_destinations_together():
         ("claude", "Claude Code picks it up from there"),
         ("codex", "Codex picks it up from there"),
         ("cursor", "Cursor picks it up from there"),
+        ("agents", "any agent following the shared convention picks it up from there"),
         ("none", "No agent scans this directory"),
     ],
 )

--- a/oopsie_data_tools/test/test_install_skill.py
+++ b/oopsie_data_tools/test/test_install_skill.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from oopsie_data_tools import cli
-from oopsie_data_tools.utils import claude_skill
+from oopsie_data_tools.utils import agent_skill_installation
 
 
 @pytest.fixture
@@ -23,20 +23,26 @@ def home(tmp_path, monkeypatch):
     project = tmp_path / "project"
     project.mkdir()
     monkeypatch.setenv("HOME", str(fake_home))
-    monkeypatch.setattr(claude_skill.Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr(
+        agent_skill_installation.Path,
+        "home",
+        classmethod(lambda cls: fake_home),
+    )
     monkeypatch.chdir(project)
     return fake_home
 
 
 def test_payload_ships_inside_the_package():
     """The skill must resolve through the installed package, not the repo layout."""
-    assert (claude_skill.bundled_skill_dir() / "SKILL.md").is_file()
+    assert (agent_skill_installation.bundled_skill_dir() / "SKILL.md").is_file()
 
 
 def test_skill_md_points_at_every_reference_page_it_ships():
     """SKILL.md is a router; a page it ships but never links is unreachable."""
-    reference = claude_skill.bundled_skill_dir() / "reference"
-    skill_md = (claude_skill.bundled_skill_dir() / "SKILL.md").read_text(encoding="utf-8")
+    reference = agent_skill_installation.bundled_skill_dir() / "reference"
+    skill_md = (agent_skill_installation.bundled_skill_dir() / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
 
     pages = sorted(p.name for p in reference.glob("*.md"))
     assert pages, "the router defers to reference pages; there must be some"
@@ -46,10 +52,12 @@ def test_skill_md_points_at_every_reference_page_it_ships():
 
 def test_skill_declares_frontmatter_an_agent_can_discover():
     """Without name/description in frontmatter the installed skill is never loaded."""
-    text = (claude_skill.bundled_skill_dir() / "SKILL.md").read_text(encoding="utf-8")
+    text = (agent_skill_installation.bundled_skill_dir() / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
     frontmatter = text.split("---\n")[1]
 
-    assert f"name: {claude_skill.SKILL_NAME}\n" in frontmatter
+    assert f"name: {agent_skill_installation.SKILL_NAME}\n" in frontmatter
     assert "description:" in frontmatter
 
 
@@ -79,7 +87,7 @@ def test_agent_selects_the_destination(home, tmp_path, agent, subdir):
 
 
 def test_only_supported_agent_choices_are_available():
-    assert set(claude_skill.AGENT_SKILL_DIRS) == {
+    assert set(agent_skill_installation.AGENT_SKILL_DIRS) == {
         "claude",
         "codex",
         "cursor",
@@ -89,7 +97,7 @@ def test_only_supported_agent_choices_are_available():
 
 
 def test_agent_mapping_keeps_labels_and_destinations_together():
-    assert claude_skill.AGENT_SKILL_DIRS == {
+    assert agent_skill_installation.AGENT_SKILL_DIRS == {
         "claude": ("Claude Code", ".claude/skills"),
         "codex": ("Codex", ".agents/skills"),
         "cursor": ("Cursor", ".agents/skills"),
@@ -119,13 +127,13 @@ def test_install_copies_the_whole_payload_tree(home, tmp_path):
     """Subdirectories install too, so a page added to the payload cannot go missing."""
     assert cli.main(["install-skill"]) == 0
 
-    source = claude_skill.bundled_skill_dir()
+    source = agent_skill_installation.bundled_skill_dir()
     dest = tmp_path / "project" / ".claude" / "skills" / "oopsie-data"
     expected = {p.relative_to(source) for p in source.rglob("*") if p.is_file()}
     # The version stamp is written at install time, so it is in the copy and not the source.
     installed = {p.relative_to(dest) for p in dest.rglob("*") if p.is_file()}
 
-    assert expected == installed - {Path(claude_skill.VERSION_STAMP)}
+    assert expected == installed - {Path(agent_skill_installation.VERSION_STAMP)}
 
 
 def test_user_scope_installs_into_the_home_directory(home, tmp_path):
@@ -181,7 +189,9 @@ def test_check_flags_a_copy_installed_from_another_version(home, tmp_path, caplo
     """The whole point: an upgraded package must not leave a stale skill looking fine."""
     assert cli.main(["install-skill"]) == 0
     installed = tmp_path / "project" / ".claude" / "skills" / "oopsie-data"
-    (installed / claude_skill.VERSION_STAMP).write_text("0.0.1\n", encoding="utf-8")
+    (installed / agent_skill_installation.VERSION_STAMP).write_text(
+        "0.0.1\n", encoding="utf-8"
+    )
 
     with caplog.at_level("INFO"):
         assert cli.main(["install-skill", "--check"]) == 1
@@ -193,7 +203,7 @@ def test_check_flags_a_copy_installed_from_another_version(home, tmp_path, caplo
 def test_check_reports_an_unstamped_copy(home, tmp_path):
     assert cli.main(["install-skill"]) == 0
     installed = tmp_path / "project" / ".claude" / "skills" / "oopsie-data"
-    (installed / claude_skill.VERSION_STAMP).unlink()
+    (installed / agent_skill_installation.VERSION_STAMP).unlink()
 
     assert cli.main(["install-skill", "--check"]) == 1
 

--- a/oopsie_data_tools/test/test_install_skill.py
+++ b/oopsie_data_tools/test/test_install_skill.py
@@ -81,12 +81,29 @@ def test_only_supported_agent_choices_are_available():
     assert set(claude_skill.AGENT_SKILL_DIRS) == {"claude", "codex", "cursor", "none"}
 
 
-def test_install_reports_destination_without_invocation_guidance(home, caplog):
-    with caplog.at_level("INFO"):
-        assert cli.main(["install-skill", "--agent", "codex"]) == 0
+def test_agent_mapping_keeps_labels_and_destinations_together():
+    assert claude_skill.AGENT_SKILL_DIRS == {
+        "claude": ("Claude Code", ".claude/skills"),
+        "codex": ("Codex", ".agents/skills"),
+        "cursor": ("Cursor", ".agents/skills"),
+        "none": ("a plain directory, scanned by nothing", "skills"),
+    }
 
-    assert "Installed the 'oopsie-data' skill to" in caplog.text
-    assert "invoke" not in caplog.text
+
+@pytest.mark.parametrize(
+    "agent,message",
+    [
+        ("claude", "Claude Code picks it up from there"),
+        ("codex", "Codex picks it up from there"),
+        ("cursor", "Cursor picks it up from there"),
+        ("none", "No agent scans this directory"),
+    ],
+)
+def test_install_reports_the_selected_destination_kind(home, caplog, agent, message):
+    with caplog.at_level("INFO"):
+        assert cli.main(["install-skill", "--agent", agent]) == 0
+
+    assert message in caplog.text
 
 
 def test_install_copies_the_whole_payload_tree(home, tmp_path):

--- a/oopsie_data_tools/test/test_install_skill.py
+++ b/oopsie_data_tools/test/test_install_skill.py
@@ -66,9 +66,8 @@ def test_default_install_lands_where_an_agent_actually_scans(home, tmp_path):
     "agent,subdir",
     [
         ("claude", ".claude/skills"),
-        ("cursor", ".cursor/skills"),
-        ("codex", ".codex/skills"),
-        ("agents", ".agents/skills"),
+        ("codex", ".agents/skills"),
+        ("cursor", ".agents/skills"),
         ("none", "skills"),
     ],
 )
@@ -76,6 +75,18 @@ def test_agent_selects_the_destination(home, tmp_path, agent, subdir):
     assert cli.main(["install-skill", "--agent", agent]) == 0
 
     assert (tmp_path / "project" / subdir / "oopsie-data" / "SKILL.md").is_file()
+
+
+def test_only_supported_agent_choices_are_available():
+    assert set(claude_skill.AGENT_SKILL_DIRS) == {"claude", "codex", "cursor", "none"}
+
+
+def test_install_reports_destination_without_invocation_guidance(home, caplog):
+    with caplog.at_level("INFO"):
+        assert cli.main(["install-skill", "--agent", "codex"]) == 0
+
+    assert "Installed the 'oopsie-data' skill to" in caplog.text
+    assert "invoke" not in caplog.text
 
 
 def test_install_copies_the_whole_payload_tree(home, tmp_path):
@@ -96,6 +107,14 @@ def test_user_scope_installs_into_the_home_directory(home, tmp_path):
 
     assert (home / ".claude" / "skills" / "oopsie-data" / "SKILL.md").is_file()
     assert not (tmp_path / "project" / ".claude").exists()
+
+
+def test_codex_user_scope_uses_shared_agents_directory(home, tmp_path):
+    assert cli.main(["install-skill", "--agent", "codex", "--user"]) == 0
+
+    assert (home / ".agents" / "skills" / "oopsie-data" / "SKILL.md").is_file()
+    assert not (home / ".codex").exists()
+    assert not (tmp_path / "project" / ".agents").exists()
 
 
 def test_refuses_to_overwrite_without_force(home, tmp_path):

--- a/oopsie_data_tools/utils/agent_skill_installation.py
+++ b/oopsie_data_tools/utils/agent_skill_installation.py
@@ -1,4 +1,4 @@
-"""Install the bundled agent skill into a user's project or home directory.
+"""Install and inspect the bundled agent skill for supported coding agents.
 
 Agents discover skills by scanning the filesystem for ``<dir>/SKILL.md``, so "installing"
 one is a directory copy — no agent CLI, and no network access, is involved.

--- a/oopsie_data_tools/utils/claude_skill.py
+++ b/oopsie_data_tools/utils/claude_skill.py
@@ -5,9 +5,9 @@ one is a directory copy — no agent CLI, and no network access, is involved.
 
 ``--agent`` picks that directory and defaults to Claude Code's, because a skill that lands
 somewhere nothing scans is not installed in any useful sense. Claude Code uses
-``.claude/skills/``; Codex and Cursor share ``.agents/skills/``; ``--agent none`` writes
-to plain ``skills/``. ``--user`` swaps the working directory for the home directory,
-making the skill available in every project.
+``.claude/skills/``; Codex, Cursor, and the generic ``agents`` choice share
+``.agents/skills/``; ``--agent none`` writes to plain ``skills/``. ``--user`` swaps the
+working directory for the home directory, making the skill available in every project.
 
 Installing is an explicit opt-in subcommand rather than anything that runs at install time:
 contributors who do not use an agent never have files written for them at all.
@@ -35,6 +35,7 @@ AGENT_SKILL_DIRS: dict[str, tuple[str, str]] = {
     "claude": ("Claude Code", ".claude/skills"),
     "codex": ("Codex", ".agents/skills"),
     "cursor": ("Cursor", ".agents/skills"),
+    "agents": ("any agent following the shared convention", ".agents/skills"),
     "none": ("a plain directory, scanned by nothing", "skills"),
 }
 

--- a/oopsie_data_tools/utils/claude_skill.py
+++ b/oopsie_data_tools/utils/claude_skill.py
@@ -4,10 +4,10 @@ Agents discover skills by scanning the filesystem for ``<dir>/SKILL.md``, so "in
 one is a directory copy — no agent CLI, and no network access, is involved.
 
 ``--agent`` picks that directory and defaults to Claude Code's, because a skill that lands
-somewhere nothing scans is not installed in any useful sense. ``--agent agents`` writes the
-vendor-neutral ``.agents/skills/`` and ``--agent none`` the plain ``skills/`` directory, for
-anyone who would rather copy it onward themselves. ``--user`` swaps the working directory
-for the home directory, making the skill available in every project.
+somewhere nothing scans is not installed in any useful sense. Claude Code uses
+``.claude/skills/``; Codex and Cursor share ``.agents/skills/``; ``--agent none`` writes
+to plain ``skills/``. ``--user`` swaps the working directory for the home directory,
+making the skill available in every project.
 
 Installing is an explicit opt-in subcommand rather than anything that runs at install time:
 contributors who do not use an agent never have files written for them at all.
@@ -31,12 +31,11 @@ VERSION_STAMP = ".skill-version"
 
 # Where each agent scans, keyed by the --agent value. Kept as data rather than prose so
 # adding an agent is one line and cannot drift from what is printed.
-AGENT_SKILL_DIRS: dict[str, tuple[str, str]] = {
-    "claude": ("Claude Code", ".claude/skills"),
-    "cursor": ("Cursor", ".cursor/skills"),
-    "codex": ("Codex", ".codex/skills"),
-    "agents": ("any agent following the convention", ".agents/skills"),
-    "none": ("a plain directory, scanned by nothing", "skills"),
+AGENT_SKILL_DIRS: dict[str, str] = {
+    "claude": ".claude/skills",
+    "codex": ".agents/skills",
+    "cursor": ".agents/skills",
+    "none": "skills",
 }
 
 DEFAULT_AGENT = "claude"
@@ -68,7 +67,7 @@ def skill_destination(
     if root is not None:
         return root / SKILL_NAME
     base = Path.home() if user else Path.cwd()
-    return base / AGENT_SKILL_DIRS[agent][1] / SKILL_NAME
+    return base / AGENT_SKILL_DIRS[agent] / SKILL_NAME
 
 
 def installed_version(dest: Path) -> str | None:
@@ -82,8 +81,9 @@ def installed_version(dest: Path) -> str | None:
 def find_installations() -> list[Path]:
     """Every installed copy of the skill under the working directory or the home directory."""
     found = []
+    subdirs = dict.fromkeys(AGENT_SKILL_DIRS.values())
     for base in (Path.cwd(), Path.home()):
-        for _, subdir in AGENT_SKILL_DIRS.values():
+        for subdir in subdirs:
             candidate = base / subdir / SKILL_NAME
             if (candidate / "SKILL.md").is_file() and candidate not in found:
                 found.append(candidate)

--- a/oopsie_data_tools/utils/claude_skill.py
+++ b/oopsie_data_tools/utils/claude_skill.py
@@ -31,11 +31,11 @@ VERSION_STAMP = ".skill-version"
 
 # Where each agent scans, keyed by the --agent value. Kept as data rather than prose so
 # adding an agent is one line and cannot drift from what is printed.
-AGENT_SKILL_DIRS: dict[str, str] = {
-    "claude": ".claude/skills",
-    "codex": ".agents/skills",
-    "cursor": ".agents/skills",
-    "none": "skills",
+AGENT_SKILL_DIRS: dict[str, tuple[str, str]] = {
+    "claude": ("Claude Code", ".claude/skills"),
+    "codex": ("Codex", ".agents/skills"),
+    "cursor": ("Cursor", ".agents/skills"),
+    "none": ("a plain directory, scanned by nothing", "skills"),
 }
 
 DEFAULT_AGENT = "claude"
@@ -67,7 +67,7 @@ def skill_destination(
     if root is not None:
         return root / SKILL_NAME
     base = Path.home() if user else Path.cwd()
-    return base / AGENT_SKILL_DIRS[agent] / SKILL_NAME
+    return base / AGENT_SKILL_DIRS[agent][1] / SKILL_NAME
 
 
 def installed_version(dest: Path) -> str | None:
@@ -81,7 +81,7 @@ def installed_version(dest: Path) -> str | None:
 def find_installations() -> list[Path]:
     """Every installed copy of the skill under the working directory or the home directory."""
     found = []
-    subdirs = dict.fromkeys(AGENT_SKILL_DIRS.values())
+    subdirs = dict.fromkeys(subdir for _, subdir in AGENT_SKILL_DIRS.values())
     for base in (Path.cwd(), Path.home()):
         for subdir in subdirs:
             candidate = base / subdir / SKILL_NAME


### PR DESCRIPTION
Fix the location of the agent files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to optional `install-skill` destination paths and module rename; no auth, data, or core workflow impact.
> 
> **Overview**
> **`install-skill` now installs Cursor and Codex skills under `.agents/skills/`** instead of `.cursor/skills/` and `.codex/skills/`, aligning with where those agents actually scan. Claude still uses `.claude/skills/`; the generic `agents` and `none` destinations are unchanged.
> 
> The implementation module is **renamed** from `claude_skill` to `agent_skill_installation`, with CLI imports and tests updated accordingly. **`find_installations`** deduplicates skill parent directories so shared paths (e.g. `.agents/skills`) are not scanned twice.
> 
> CLI help, docstrings, and examples document the shared layout; tests lock in the agent→path mapping, install log messages, and Codex `--user` installing to `~/.agents/skills/` (not `~/.codex`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8440c1a8f7515c600ad5c11c1f4cd63d143e099a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->