### PR TITLE
increase video crf from 23 to 19

### DIFF
--- a/oopsie_data_tools/annotation_tool/episode_recorder.py
+++ b/oopsie_data_tools/annotation_tool/episode_recorder.py
@@ -41,6 +41,8 @@ VALID_ACTION_KEYS = {
     "gripper_binary",
 }
 
+VIDEO_CRF = 19
+
 
 def write_mp4(video_path: Path, frames: np.ndarray, fps: float) -> None:
     """Write RGB frames to an MP4 file.
@@ -65,6 +67,8 @@ def write_mp4(video_path: Path, frames: np.ndarray, fps: float) -> None:
         mode="I",
         fps=float(fps),
         codec="libx264",
+        quality=None,
+        output_params=["-crf", str(VIDEO_CRF)],
     ) as writer:
         for frame in frames:
             writer.append_data(np.asarray(frame, dtype=np.uint8))

--- a/oopsie_data_tools/test/test_episode_recorder.py
+++ b/oopsie_data_tools/test/test_episode_recorder.py
@@ -8,7 +8,10 @@ import h5py
 import numpy as np
 import pytest
 
-from oopsie_data_tools.annotation_tool.episode_recorder import EpisodeRecorder, write_mp4
+from oopsie_data_tools.annotation_tool.episode_recorder import (
+    EpisodeRecorder,
+    write_mp4,
+)
 from oopsie_data_tools.utils.robot_profile.robot_profile import RobotProfile
 
 
@@ -289,3 +292,38 @@ def test_save_raises_without_steps(recorder):
 def test_write_mp4_rejects_a_bad_frame_array(tmp_path, shape):
     with pytest.raises(ValueError):
         write_mp4(tmp_path / "out.mp4", np.zeros(shape, dtype=np.uint8), fps=10.0)
+
+
+def test_write_mp4_uses_explicit_crf(monkeypatch, tmp_path):
+    writer_calls = []
+
+    class FakeWriter:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def append_data(self, frame):
+            pass
+
+    def fake_get_writer(*args, **kwargs):
+        writer_calls.append((args, kwargs))
+        return FakeWriter()
+
+    monkeypatch.setattr(
+        "oopsie_data_tools.annotation_tool.episode_recorder.imageio.get_writer",
+        fake_get_writer,
+    )
+
+    write_mp4(
+        tmp_path / "out.mp4",
+        np.zeros((1, 64, 64, 3), dtype=np.uint8),
+        fps=10.0,
+    )
+
+    assert len(writer_calls) == 1
+    _, kwargs = writer_calls[0]
+    assert kwargs["codec"] == "libx264"
+    assert kwargs["quality"] is None
+    assert kwargs["output_params"] == ["-crf", "19"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oopsie-data-tools"
-version = "0.9.2"
+version = "0.9.3"
 description = "Collect, annotate, validate and upload robotic manipulation rollout data."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Currently, we are using mp4 compression with CRF 23, the imageio default. This PR reduces the mp4 compression and increases CRF to 19.

We pay a ~1.5x storage cost. I tested on 5 random roboarena videos: 
| Video | Duration | CRF 23 | CRF 19 | Increase |
|---|---:|---:|---:|---:|
| `episode_000397_right.mp4` | 6.9s | 0.128 MB | 0.179 MB | 40.1% |
| `episode_000356_left.mp4` | 40.1s | 0.586 MB | 0.876 MB | 49.4% |
| `episode_000437_wrist.mp4` | 40.1s | 0.800 MB | 1.171 MB | 46.5% |
| `episode_000119_left.mp4` | 40.1s | 1.090 MB | 1.782 MB | 63.5% |
| `episode_000257_right.mp4` | 40.1s | 0.702 MB | 1.021 MB | 45.4% |

After the change, the software version is also bumped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes FFmpeg encoding parameters for newly written videos; no schema, auth, or playback logic changes, with the main tradeoff being increased storage use.
> 
> **Overview**
> Episode rollout MP4s are now encoded with **libx264 CRF 19** instead of relying on imageio’s default (~CRF 23). `write_mp4` sets `quality=None` and passes `output_params=["-crf", "19"]` via a new `VIDEO_CRF` constant, so all camera videos written during recording use the same setting.
> 
> A unit test asserts those `imageio.get_writer` kwargs. Package version is bumped to **0.9.3**. Expect **higher visual quality** and **roughly ~1.5× larger** MP4 files on new episodes (per author benchmarks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44da94011c95221550aa0a948383d6211b210ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->