### PR TITLE
Version bump notice

### DIFF
--- a/oopsie_data_tools/cli.py
+++ b/oopsie_data_tools/cli.py
@@ -48,7 +48,11 @@ def _interactive_update_warning() -> str | None:
     """Return an update notice only when a person is running the command in a terminal."""
     if not sys.stderr.isatty():
         return None
-    from oopsie_data_tools.utils.update_check import update_warning_message
+    try:
+        from oopsie_data_tools.utils.update_check import update_warning_message
+    except Exception:
+        # A broken optional update checker must never prevent the requested command.
+        return None
 
     return update_warning_message()
 
@@ -853,8 +857,9 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     # Run outside Click's group callback so eager options such as --help and --version,
     # as well as every subcommand, all receive the same end-of-command update notice.
-    update_warning = _interactive_update_warning()
+    update_warning = None
     try:
+        update_warning = _interactive_update_warning()
         return cli.main(args=argv, prog_name="oopsie-data", standalone_mode=False) or 0
     except click.exceptions.Exit as e:
         return e.exit_code

--- a/oopsie_data_tools/cli.py
+++ b/oopsie_data_tools/cli.py
@@ -139,6 +139,13 @@ def cli(ctx: click.Context, config_dir: Path | None) -> None:
         os.environ[ENV_CONFIG_DIR] = str(config_dir.expanduser().resolve())
     ctx.obj = {"config_dir_from_flag": config_dir is not None}
 
+    # Keep automation deterministic and fast; a person at a terminal gets a cached,
+    # best-effort notice when a newer package is available.
+    if sys.stderr.isatty():
+        from oopsie_data_tools.utils.update_check import warn_if_outdated
+
+        warn_if_outdated()
+
     # A bare 'oopsie-data' is someone looking for the commands, so show them.
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())

--- a/oopsie_data_tools/cli.py
+++ b/oopsie_data_tools/cli.py
@@ -39,6 +39,20 @@ logger = logging.getLogger(__name__)
 DIR = click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path)
 
 
+def _emit_update_warning(message: str) -> None:
+    """Print the complete update notice in yellow without contaminating stdout."""
+    click.secho(message, fg="yellow", err=True)
+
+
+def _interactive_update_warning() -> str | None:
+    """Return an update notice only when a person is running the command in a terminal."""
+    if not sys.stderr.isatty():
+        return None
+    from oopsie_data_tools.utils.update_check import update_warning_message
+
+    return update_warning_message()
+
+
 # ── machine-readable output ───────────────────────────────────────────────────
 
 
@@ -138,13 +152,6 @@ def cli(ctx: click.Context, config_dir: Path | None) -> None:
     if config_dir is not None:
         os.environ[ENV_CONFIG_DIR] = str(config_dir.expanduser().resolve())
     ctx.obj = {"config_dir_from_flag": config_dir is not None}
-
-    # Keep automation deterministic and fast; a person at a terminal gets a cached,
-    # best-effort notice when a newer package is available.
-    if sys.stderr.isatty():
-        from oopsie_data_tools.utils.update_check import warn_if_outdated
-
-        warn_if_outdated()
 
     # A bare 'oopsie-data' is someone looking for the commands, so show them.
     if ctx.invoked_subcommand is None:
@@ -844,6 +851,9 @@ def install_skill_cmd(agent, user, force, check):
 
 def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+    # Run outside Click's group callback so eager options such as --help and --version,
+    # as well as every subcommand, all receive the same end-of-command update notice.
+    update_warning = _interactive_update_warning()
     try:
         return cli.main(args=argv, prog_name="oopsie-data", standalone_mode=False) or 0
     except click.exceptions.Exit as e:
@@ -861,6 +871,9 @@ def main(argv: list[str] | None = None) -> int:
         # Config/auth problems already carry an actionable message; don't dump a traceback.
         logger.error("%s", e)
         return 1
+    finally:
+        if update_warning:
+            _emit_update_warning(update_warning)
 
 
 if __name__ == "__main__":

--- a/oopsie_data_tools/test/test_update_check.py
+++ b/oopsie_data_tools/test/test_update_check.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import json
 
 import click
@@ -119,3 +120,36 @@ def test_cli_prints_update_warning_in_yellow_on_stderr(monkeypatch):
     cli._emit_update_warning("update notice")
 
     assert calls == [("update notice", {"fg": "yellow", "err": True})]
+
+
+def test_update_check_import_failure_does_not_break_cli(monkeypatch):
+    class InteractiveStderr:
+        @staticmethod
+        def isatty():
+            return True
+
+    real_import = builtins.__import__
+
+    def fail_update_check_import(name, *args, **kwargs):
+        if name == "oopsie_data_tools.utils.update_check":
+            raise ImportError("broken optional module")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(cli.sys, "stderr", InteractiveStderr())
+    monkeypatch.setattr(builtins, "__import__", fail_update_check_import)
+
+    assert cli._interactive_update_warning() is None
+
+
+def test_ctrl_c_during_update_check_uses_cli_interrupt_handler(monkeypatch, caplog):
+    def interrupted():
+        raise KeyboardInterrupt
+
+    emitted = []
+    caplog.set_level("INFO")
+    monkeypatch.setattr(cli, "_interactive_update_warning", interrupted)
+    monkeypatch.setattr(cli, "_emit_update_warning", emitted.append)
+
+    assert cli.main(["--version"]) == 130
+    assert "Interrupted." in caplog.text
+    assert emitted == []

--- a/oopsie_data_tools/test/test_update_check.py
+++ b/oopsie_data_tools/test/test_update_check.py
@@ -1,0 +1,82 @@
+"""Tests for the optional PyPI update notification."""
+
+from __future__ import annotations
+
+import json
+
+from oopsie_data_tools.utils import update_check
+
+
+def test_newer_release_is_reported_and_cached(tmp_path, monkeypatch):
+    cache = tmp_path / "update-check.json"
+    monkeypatch.setattr(update_check.metadata, "version", lambda _: "0.9.3")
+    monkeypatch.setattr(update_check, "_fetch_latest_version", lambda: "0.9.4")
+
+    assert update_check.available_update(cache_path=cache, now=1000) == ("0.9.3", "0.9.4")
+    assert json.loads(cache.read_text(encoding="utf-8")) == {
+        "checked_at": 1000,
+        "latest_version": "0.9.4",
+    }
+
+
+def test_fresh_cache_avoids_the_network(tmp_path, monkeypatch):
+    cache = tmp_path / "update-check.json"
+    cache.write_text(
+        json.dumps({"checked_at": 1000, "latest_version": "0.9.4"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(update_check.metadata, "version", lambda _: "0.9.3")
+
+    def unexpected_request():
+        raise AssertionError("fresh cache should avoid PyPI")
+
+    monkeypatch.setattr(update_check, "_fetch_latest_version", unexpected_request)
+
+    assert update_check.available_update(cache_path=cache, now=1001) == ("0.9.3", "0.9.4")
+
+
+def test_current_release_does_not_warn(tmp_path, monkeypatch):
+    monkeypatch.setattr(update_check.metadata, "version", lambda _: "0.9.4")
+    monkeypatch.setattr(update_check, "_fetch_latest_version", lambda: "0.9.4")
+
+    assert update_check.available_update(cache_path=tmp_path / "cache", now=1000) is None
+
+
+def test_network_failure_is_silent_and_cached(tmp_path, monkeypatch):
+    cache = tmp_path / "update-check.json"
+    monkeypatch.setattr(update_check.metadata, "version", lambda _: "0.9.3")
+
+    def unavailable():
+        raise OSError("offline")
+
+    monkeypatch.setattr(update_check, "_fetch_latest_version", unavailable)
+
+    assert update_check.available_update(cache_path=cache, now=1000) is None
+    assert json.loads(cache.read_text(encoding="utf-8")) == {
+        "checked_at": 1000,
+        "latest_version": None,
+    }
+
+
+def test_check_can_be_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv(update_check.DISABLE_ENV, "1")
+
+    def unexpected_version_lookup(_):
+        raise AssertionError("disabled check should do no work")
+
+    monkeypatch.setattr(update_check.metadata, "version", unexpected_version_lookup)
+
+    assert update_check.available_update(cache_path=tmp_path / "cache", now=1000) is None
+
+
+def test_warning_includes_versions_and_upgrade_command(monkeypatch, caplog):
+    monkeypatch.setattr(
+        update_check,
+        "available_update",
+        lambda: ("0.9.3", "0.9.4"),
+    )
+
+    update_check.warn_if_outdated()
+
+    assert "0.9.3 -> 0.9.4" in caplog.text
+    assert "pip install --upgrade oopsie-data-tools" in caplog.text

--- a/oopsie_data_tools/test/test_update_check.py
+++ b/oopsie_data_tools/test/test_update_check.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import json
 
+import click
+import pytest
+
+from oopsie_data_tools import cli
 from oopsie_data_tools.utils import update_check
 
 
@@ -69,14 +73,49 @@ def test_check_can_be_disabled(tmp_path, monkeypatch):
     assert update_check.available_update(cache_path=tmp_path / "cache", now=1000) is None
 
 
-def test_warning_includes_versions_and_upgrade_command(monkeypatch, caplog):
+def test_warning_includes_requested_guidance(monkeypatch):
     monkeypatch.setattr(
         update_check,
         "available_update",
         lambda: ("0.9.3", "0.9.4"),
     )
 
-    update_check.warn_if_outdated()
+    warning = update_check.update_warning_message()
 
-    assert "0.9.3 -> 0.9.4" in caplog.text
-    assert "pip install --upgrade oopsie-data-tools" in caplog.text
+    assert warning is not None
+    assert "0.9.3 -> 0.9.4" in warning
+    assert "important updates and fixes for logging, converting, and contributing data" in warning
+    assert "All updates are backwards compatible and won't require you to change any code" in warning
+    assert "pip install --upgrade oopsie-data-tools" in warning
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["show-config"],
+        ["--help"],
+        ["--version"],
+    ],
+    ids=["subcommand", "help", "version"],
+)
+def test_every_cli_invocation_prints_warning_at_the_end(argv, monkeypatch):
+    emitted = []
+    monkeypatch.setattr(cli, "_interactive_update_warning", lambda: "update notice")
+    monkeypatch.setattr(cli, "_emit_update_warning", emitted.append)
+
+    assert cli.main(argv) == 0
+
+    assert emitted == ["update notice"]
+
+
+def test_cli_prints_update_warning_in_yellow_on_stderr(monkeypatch):
+    calls = []
+
+    def fake_secho(message, **kwargs):
+        calls.append((message, kwargs))
+
+    monkeypatch.setattr(click, "secho", fake_secho)
+
+    cli._emit_update_warning("update notice")
+
+    assert calls == [("update notice", {"fg": "yellow", "err": True})]

--- a/oopsie_data_tools/utils/update_check.py
+++ b/oopsie_data_tools/utils/update_check.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
 import time
@@ -17,9 +16,6 @@ PYPI_JSON_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 CHECK_INTERVAL_SECONDS = 24 * 60 * 60
 REQUEST_TIMEOUT_SECONDS = 1.0
 DISABLE_ENV = "OOPSIE_DISABLE_UPDATE_CHECK"
-
-logger = logging.getLogger(__name__)
-
 
 def _cache_path() -> Path:
     xdg = os.environ.get("XDG_CACHE_HOME", "").strip()
@@ -108,18 +104,19 @@ def available_update(
     return installed, latest
 
 
-def warn_if_outdated() -> None:
-    """Log an actionable update notice, without ever disrupting the command."""
+def update_warning_message() -> str | None:
+    """Return an actionable update notice, without ever disrupting the command."""
     try:
         update = available_update()
     except Exception:  # pragma: no cover - the update check must remain strictly optional
-        return
+        return None
     if update is None:
-        return
+        return None
     installed, latest = update
-    logger.warning(
-        "A newer oopsie-data release is available: %s -> %s. "
-        "Upgrade with: pip install --upgrade oopsie-data-tools",
-        installed,
-        latest,
+    return (
+        f"A newer oopsie-data release is available: {installed} -> {latest}.\n"
+        "Newer oopsie-data-tools include important updates and fixes for logging, "
+        "converting, and contributing data, please update your version timely. All updates "
+        "are backwards compatible and won't require you to change any code.\n"
+        "Upgrade with: pip install --upgrade oopsie-data-tools"
     )

--- a/oopsie_data_tools/utils/update_check.py
+++ b/oopsie_data_tools/utils/update_check.py
@@ -1,0 +1,125 @@
+"""Best-effort notification when a newer ``oopsie-data-tools`` release exists."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+import urllib.request
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+PACKAGE_NAME = "oopsie-data-tools"
+PYPI_JSON_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
+CHECK_INTERVAL_SECONDS = 24 * 60 * 60
+REQUEST_TIMEOUT_SECONDS = 1.0
+DISABLE_ENV = "OOPSIE_DISABLE_UPDATE_CHECK"
+
+logger = logging.getLogger(__name__)
+
+
+def _cache_path() -> Path:
+    xdg = os.environ.get("XDG_CACHE_HOME", "").strip()
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".cache"
+    return base / "oopsie-data" / "update-check.json"
+
+
+def _release_tuple(version: str) -> tuple[int, int, int] | None:
+    """Return a comparable tuple for the stable ``X.Y.Z`` versions this project ships."""
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", version.strip())
+    return tuple(int(part) for part in match.groups()) if match else None
+
+
+def _read_cache(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return payload if isinstance(payload, dict) else {}
+    except (OSError, ValueError, TypeError):
+        return {}
+
+
+def _write_cache(path: Path, checked_at: float, latest_version: str | None) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        temporary.write_text(
+            json.dumps({"checked_at": checked_at, "latest_version": latest_version}),
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        # A read-only home directory should not turn an optional update check into a failure.
+        return
+
+
+def _fetch_latest_version() -> str:
+    request = urllib.request.Request(
+        PYPI_JSON_URL,
+        headers={"User-Agent": f"{PACKAGE_NAME} update-check"},
+    )
+    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        payload = json.load(response)
+    return str(payload["info"]["version"])
+
+
+def available_update(
+    *, cache_path: Path | None = None, now: float | None = None
+) -> tuple[str, str] | None:
+    """Return ``(installed, latest)`` when PyPI has a newer stable release.
+
+    Network and cache errors deliberately return ``None``. A failed request is cached as an
+    attempt too, so an offline machine does not absorb the timeout on every invocation.
+    """
+    if os.environ.get(DISABLE_ENV, "").strip().lower() in {"1", "true", "yes"}:
+        return None
+
+    try:
+        installed = metadata.version(PACKAGE_NAME)
+    except metadata.PackageNotFoundError:
+        return None
+
+    current_time = time.time() if now is None else now
+    path = _cache_path() if cache_path is None else cache_path
+    cached = _read_cache(path)
+    checked_at = cached.get("checked_at")
+    latest = cached.get("latest_version")
+    is_fresh = (
+        isinstance(checked_at, (int, float))
+        and current_time - checked_at < CHECK_INTERVAL_SECONDS
+        and current_time >= checked_at
+    )
+
+    if not is_fresh:
+        try:
+            latest = _fetch_latest_version()
+        except (OSError, ValueError, KeyError, TypeError):
+            latest = latest if isinstance(latest, str) else None
+        _write_cache(path, current_time, latest)
+
+    if not isinstance(latest, str):
+        return None
+    installed_release = _release_tuple(installed)
+    latest_release = _release_tuple(latest)
+    if installed_release is None or latest_release is None or latest_release <= installed_release:
+        return None
+    return installed, latest
+
+
+def warn_if_outdated() -> None:
+    """Log an actionable update notice, without ever disrupting the command."""
+    try:
+        update = available_update()
+    except Exception:  # pragma: no cover - the update check must remain strictly optional
+        return
+    if update is None:
+        return
+    installed, latest = update
+    logger.warning(
+        "A newer oopsie-data release is available: %s -> %s. "
+        "Upgrade with: pip install --upgrade oopsie-data-tools",
+        installed,
+        latest,
+    )

--- a/oopsie_data_tools/utils/update_check.py
+++ b/oopsie_data_tools/utils/update_check.py
@@ -114,7 +114,7 @@ def update_warning_message() -> str | None:
         return None
     installed, latest = update
     return (
-        f"A newer oopsie-data release is available: {installed} -> {latest}.\n"
+        f"A newer oopsie-data-tools release is available: {installed} -> {latest}.\n"
         "Newer oopsie-data-tools include important updates and fixes for logging, "
         "converting, and contributing data, please update your version timely. All updates "
         "are backwards compatible and won't require you to change any code.\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oopsie-data-tools"
-version = "0.9.3"
+version = "1.0.0"
 description = "Collect, annotate, validate and upload robotic manipulation rollout data."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
This prints out a warning to users when their oopsie-data-tools is outdated. See example below:

<img width="951" height="132" alt="image" src="https://github.com/user-attachments/assets/0a131c3d-f010-4965-ab04-72042c6f0e9a" />

This also bumps the version to 1.0.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional UX that uses stderr and a best-effort PyPI fetch; it does not change command outcomes or core data workflows.
> 
> **Overview**
> Adds an **optional end-of-command update notice** for interactive `oopsie-data` runs when a newer release is on PyPI, and bumps the package version to **1.0.0**.
> 
> A new `update_check` helper compares the installed version to PyPI (1s timeout), caches results for 24h under XDG/`~/.cache`, and can be turned off with `OOPSIE_DISABLE_UPDATE_CHECK`. Failures and import errors stay silent so commands still succeed.
> 
> `main()` resolves the notice before Click runs (so `--help`, `--version`, and subcommands behave the same), then prints it in **yellow on stderr** in a `finally` block so stdout stays clean for `--json`. Warnings only run when stderr is a TTY.
> 
> Tests cover caching, offline behavior, disable flag, CLI wiring, and interrupt handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce1b8869cc97f665b1550c18c5eaacc4ac6b1d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->