### PR TITLE
validator checks video CRF

### DIFF
--- a/oopsie_data_tools/annotation_tool/episode_recorder.py
+++ b/oopsie_data_tools/annotation_tool/episode_recorder.py
@@ -26,6 +26,7 @@ from oopsie_data_tools.utils.validation.array_validation import (
 )
 from oopsie_data_tools.utils.validation.episode_data import EpisodeData, VideoInfo
 from oopsie_data_tools.utils.validation.episode_validator import validate_episode
+from oopsie_data_tools.utils.video_encoding import VIDEO_CRF
 
 REQUIRED_OBSERVATION_KEYS = ["robot_state", "image_observation"]
 
@@ -40,9 +41,6 @@ VALID_ACTION_KEYS = {
     "gripper_position",
     "gripper_binary",
 }
-
-VIDEO_CRF = 19
-
 
 def write_mp4(video_path: Path, frames: np.ndarray, fps: float) -> None:
     """Write RGB frames to an MP4 file.
@@ -581,7 +579,12 @@ class EpisodeRecorder:
                 for key in self.robot_profile.action_space
             },
             videos={
-                cam: VideoInfo.from_frames(self.frames[cam], fps=self.robot_profile.control_freq) for cam in self.camera_names
+                cam: VideoInfo.from_frames(
+                    self.frames[cam],
+                    fps=self.robot_profile.control_freq,
+                    crf=float(VIDEO_CRF),
+                )
+                for cam in self.camera_names
             },
             annotations=data.get("episode_annotations", None),
         )

--- a/oopsie_data_tools/cli.py
+++ b/oopsie_data_tools/cli.py
@@ -39,9 +39,25 @@ logger = logging.getLogger(__name__)
 DIR = click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path)
 
 
+class _CliFormatter(logging.Formatter):
+    """Give every warning-level CLI log record the same yellow styling."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = super().format(record)
+        if record.levelno == logging.WARNING:
+            return click.style(message, fg="yellow")
+        return message
+
+
+def _configure_cli_logging() -> None:
+    handler = logging.StreamHandler()
+    handler.setFormatter(_CliFormatter("%(message)s"))
+    logging.basicConfig(level=logging.INFO, handlers=[handler])
+
+
 def _emit_update_warning(message: str) -> None:
-    """Print the complete update notice in yellow without contaminating stdout."""
-    click.secho(message, fg="yellow", err=True)
+    """Emit the update notice through the shared warning-level formatting path."""
+    logger.warning(message)
 
 
 def _interactive_update_warning() -> str | None:
@@ -854,7 +870,7 @@ def install_skill_cmd(agent, user, force, check):
 
 
 def main(argv: list[str] | None = None) -> int:
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    _configure_cli_logging()
     # Run outside Click's group callback so eager options such as --help and --version,
     # as well as every subcommand, all receive the same end-of-command update notice.
     update_warning = None

--- a/oopsie_data_tools/test/fixtures/make_invalid.py
+++ b/oopsie_data_tools/test/fixtures/make_invalid.py
@@ -103,7 +103,7 @@ def _write_video(
     frames = np.full((n_frames, size, size, 3), color, dtype=np.uint8)
     with imageio.get_writer(
         str(path), format="FFMPEG", mode="I", fps=10, codec="libx264",
-        output_params=["-crf", "28"],
+        output_params=["-crf", "19"],
     ) as writer:
         for frame in frames:
             writer.append_data(frame)

--- a/oopsie_data_tools/test/fixtures/make_valid.py
+++ b/oopsie_data_tools/test/fixtures/make_valid.py
@@ -78,7 +78,7 @@ def _write_video(path: Path, color: tuple[int, int, int], n_frames: int = 25, si
         mode="I",
         fps=10,
         codec="libx264",
-        output_params=["-crf", "28"],
+        output_params=["-crf", "19"],
     ) as writer:
         for frame in frames:
             writer.append_data(frame)

--- a/oopsie_data_tools/test/test_update_check.py
+++ b/oopsie_data_tools/test/test_update_check.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import builtins
 import json
 
-import click
 import pytest
 
 from oopsie_data_tools import cli
@@ -109,17 +108,17 @@ def test_every_cli_invocation_prints_warning_at_the_end(argv, monkeypatch):
     assert emitted == ["update notice"]
 
 
-def test_cli_prints_update_warning_in_yellow_on_stderr(monkeypatch):
+def test_update_notice_uses_the_shared_warning_logger(monkeypatch):
     calls = []
 
-    def fake_secho(message, **kwargs):
-        calls.append((message, kwargs))
+    def fake_warning(message):
+        calls.append(message)
 
-    monkeypatch.setattr(click, "secho", fake_secho)
+    monkeypatch.setattr(cli.logger, "warning", fake_warning)
 
     cli._emit_update_warning("update notice")
 
-    assert calls == [("update notice", {"fg": "yellow", "err": True})]
+    assert calls == ["update notice"]
 
 
 def test_update_check_import_failure_does_not_break_cli(monkeypatch):

--- a/oopsie_data_tools/test/test_validate.py
+++ b/oopsie_data_tools/test/test_validate.py
@@ -37,6 +37,7 @@ from oopsie_data_tools.utils.hf_upload import run_validation
 from oopsie_data_tools.utils.validation.episode_loader import detect_x264_crf
 from oopsie_data_tools.utils.validation.errors import EpisodeValidationError
 from oopsie_data_tools.utils.validation.validation_utils import (
+    VALIDATION_LOGGER_NAME,
     validate_h5_file,
     validate_session_dir,
 )
@@ -531,6 +532,36 @@ class TestBetterErrors:
         log_path = tmp_path / "validate.log"
         assert validate_h5_file(str(valid_episode), log_path=str(log_path)) is True
         assert log_path.exists(), "a log path that is accepted but never written is not a log"
+
+    def test_crf_advisory_is_written_to_log_path(
+        self, valid_episode, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "oopsie_data_tools.utils.validation.episode_loader.detect_x264_crf",
+            lambda _path: 23.0,
+        )
+        log_path = tmp_path / "validate.log"
+        validation_logger = logging.getLogger(VALIDATION_LOGGER_NAME)
+        previous_handlers = set(validation_logger.handlers)
+
+        try:
+            assert (
+                validate_h5_file(
+                    str(valid_episode),
+                    strict_annotation_check=True,
+                    log_path=log_path,
+                )
+                is True
+            )
+            log_text = log_path.read_text(encoding="utf-8")
+        finally:
+            for handler in set(validation_logger.handlers) - previous_handlers:
+                handler.close()
+                validation_logger.removeHandler(handler)
+
+        assert "WARNING" in log_text
+        assert "detected CRF 23.0" in log_text
+        assert "validation will continue" in log_text
 
 
 # ---------------------------------------------------------------------------

--- a/oopsie_data_tools/test/test_validate.py
+++ b/oopsie_data_tools/test/test_validate.py
@@ -24,14 +24,17 @@ TestValidateSessionDir    – directory-level validation
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import h5py
 import numpy as np
 import pytest
 
+from oopsie_data_tools.cli import _CliFormatter
 from oopsie_data_tools.test.fixtures.make_valid import write_valid_episode
 from oopsie_data_tools.utils.hf_upload import run_validation
+from oopsie_data_tools.utils.validation.episode_loader import detect_x264_crf
 from oopsie_data_tools.utils.validation.errors import EpisodeValidationError
 from oopsie_data_tools.utils.validation.validation_utils import (
     validate_h5_file,
@@ -353,6 +356,79 @@ class TestVideos:
 
         with pytest.raises(AssertionError, match="Video too small"):
             validate_h5_file(str(h5_path), strict_annotation_check=True)
+
+    @pytest.mark.parametrize(
+        "crf, expected_message",
+        [
+            (18.0, None),
+            (19.0, None),
+            (23.0, "detected CRF 23.0"),
+            (None, "CRF could not be determined"),
+        ],
+        ids=["better-than-target", "at-target", "too-lossy", "unknown"],
+    )
+    def test_crf_check_is_advisory(
+        self, valid_episode, monkeypatch, caplog, crf, expected_message
+    ):
+        monkeypatch.setattr(
+            "oopsie_data_tools.utils.validation.episode_loader.detect_x264_crf",
+            lambda _path: crf,
+        )
+        caplog.set_level(logging.WARNING)
+
+        assert validate_h5_file(str(valid_episode), strict_annotation_check=True) is True
+
+        if expected_message is None:
+            assert "[video quality]" not in caplog.text
+        else:
+            assert expected_message in caplog.text
+            assert "validation will continue" in caplog.text
+
+    def test_detect_x264_crf_reads_embedded_encoder_options(self, tmp_path):
+        video = tmp_path / "encoder-options.mp4"
+        video.write_bytes(
+            b"binary prefix x264 - core 164 - H.264 encoder - options: "
+            b"cabac=1 rc=crf mbtree=1 crf=23.0 qcomp=0.60 binary suffix"
+        )
+
+        assert detect_x264_crf(str(video)) == 23.0
+
+    def test_detect_x264_crf_reads_an_encoded_fixture(self, valid_episode):
+        with h5py.File(valid_episode, "r") as f:
+            rel = f["observations/video_paths/front"][()].decode("utf-8")
+
+        assert detect_x264_crf(str(valid_episode.parent / rel)) == 19.0
+
+    def test_detect_x264_crf_does_not_guess_from_unrelated_metadata(self, tmp_path):
+        video = tmp_path / "no-encoder-options.mp4"
+        video.write_bytes(b"description=export crf=28.0 bitrate=1234")
+
+        assert detect_x264_crf(str(video)) is None
+
+    @pytest.mark.parametrize(
+        "level, is_yellow",
+        [
+            (logging.INFO, False),
+            (logging.WARNING, True),
+            (logging.ERROR, False),
+        ],
+        ids=["info", "warning", "error"],
+    )
+    def test_cli_formatter_only_colors_warning_level(self, level, is_yellow):
+        record = logging.LogRecord(
+            name="validator",
+            level=level,
+            pathname=__file__,
+            lineno=1,
+            msg="log message",
+            args=(),
+            exc_info=None,
+        )
+
+        rendered = _CliFormatter("%(message)s").format(record)
+
+        assert ("\x1b[33m" in rendered) is is_yellow
+        assert "log message" in rendered
 
 
 # ---------------------------------------------------------------------------

--- a/oopsie_data_tools/utils/validation/episode_data.py
+++ b/oopsie_data_tools/utils/validation/episode_data.py
@@ -18,14 +18,18 @@ class VideoInfo:
     fps: float
     width: int
     height: int
+    path: Optional[str] = None
+    crf: Optional[float] = None
 
     @classmethod
-    def from_frames(cls, frames: list[np.ndarray], fps: float) -> VideoInfo:
+    def from_frames(
+        cls, frames: list[np.ndarray], fps: float, crf: Optional[float] = None
+    ) -> VideoInfo:
         """Build VideoInfo from in-memory frame buffers (recorder pre-save path)."""
         if not frames:
             raise ValueError("Cannot build VideoInfo from empty frame list")
         h, w = frames[0].shape[:2]
-        return cls(frame_count=len(frames), fps=fps, width=w, height=h)
+        return cls(frame_count=len(frames), fps=fps, width=w, height=h, crf=crf)
 
 
 @dataclass

--- a/oopsie_data_tools/utils/validation/episode_loader.py
+++ b/oopsie_data_tools/utils/validation/episode_loader.py
@@ -11,8 +11,9 @@ It does NOT perform semantic validation — that is episode_validator's job.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import cv2
 import h5py
@@ -34,6 +35,14 @@ _OOPSIE_V1_REQUIRED_ROOT_ATTRS = (
     "robot_profile",
 )
 
+_X264_CRF_PATTERN = re.compile(
+    rb"x264 - core.{0,8192}?options:.{0,8192}?\brc=crf\b.{0,2048}?\bcrf=([0-9]+(?:\.[0-9]+)?)",
+    re.DOTALL,
+)
+_CRF_SCAN_CHUNK_SIZE = 64 * 1024
+_CRF_SCAN_OVERLAP = 16 * 1024
+_CRF_SCAN_LIMIT = 8 * 1024 * 1024
+
 
 # ── HDF5 scalar helpers ────────────────────────────────────────────────────────
 
@@ -43,6 +52,31 @@ def _read_string_dataset(ds: h5py.Dataset) -> str:
 
 
 # ── Video loading ──────────────────────────────────────────────────────────────
+
+
+def detect_x264_crf(mp4_path: str) -> Optional[float]:
+    """Return an x264 CRF embedded in the video bitstream, if one is recoverable.
+
+    libx264 normally writes its encoder options into an H.264 user-data SEI message. CRF
+    is not required MP4 metadata, though, so an absent or stripped message is reported as
+    ``None`` rather than guessed from bitrate or quantizer statistics.
+    """
+    overlap = b""
+    remaining = _CRF_SCAN_LIMIT
+    try:
+        with open(mp4_path, "rb") as stream:
+            while remaining and (
+                chunk := stream.read(min(_CRF_SCAN_CHUNK_SIZE, remaining))
+            ):
+                remaining -= len(chunk)
+                window = overlap + chunk
+                match = _X264_CRF_PATTERN.search(window)
+                if match:
+                    return float(match.group(1))
+                overlap = window[-_CRF_SCAN_OVERLAP:]
+    except OSError:
+        return None
+    return None
 
 
 def load_video_info(mp4_path: str) -> VideoInfo:
@@ -66,7 +100,14 @@ def load_video_info(mp4_path: str) -> VideoInfo:
             raise EpisodeValidationError(f"Invalid FPS ({fps}): {mp4_path}")
         if not (frame_count > 0):
             raise EpisodeValidationError(f"Invalid frame count ({frame_count}): {mp4_path}")
-        return VideoInfo(frame_count=frame_count, fps=fps, width=width, height=height)
+        return VideoInfo(
+            frame_count=frame_count,
+            fps=fps,
+            width=width,
+            height=height,
+            path=mp4_path,
+            crf=detect_x264_crf(mp4_path),
+        )
     finally:
         cap.release()
 

--- a/oopsie_data_tools/utils/validation/episode_validator.py
+++ b/oopsie_data_tools/utils/validation/episode_validator.py
@@ -9,6 +9,8 @@ with no file I/O.  This makes the same validation callable from:
 from __future__ import annotations
 
 import json
+import logging
+import os
 from typing import Any
 
 import numpy as np
@@ -27,12 +29,14 @@ from oopsie_data_tools.utils.validation.array_validation import (
 )
 from oopsie_data_tools.utils.validation.episode_data import EpisodeData
 from oopsie_data_tools.utils.validation.errors import EpisodeValidationError
+from oopsie_data_tools.utils.video_encoding import VIDEO_CRF
 
 MAX_IMAGE_SIZE = 1280
 MIN_IMAGE_SIZE = 180
 # Bounds on episode *duration*, not step count: trajectory_length / control_freq.
 MIN_EPISODE_DURATION_S = 1
 MAX_EPISODE_DURATION_S = 600
+logger = logging.getLogger(__name__)
 
 
 def validate_episode(data: EpisodeData, strict_annotation_check: bool = False) -> None:
@@ -246,6 +250,20 @@ def _validate_video_specs(data: EpisodeData) -> None:
 
     frame_counts: dict[str, int] = {}
     for cam, info in data.videos.items():
+        video_label = os.path.basename(info.path) if info.path else f"camera {cam}"
+        if info.crf is None:
+            logger.warning(
+                "[video quality] %s: CRF could not be determined; validation will continue.",
+                video_label,
+            )
+        elif info.crf > VIDEO_CRF:
+            logger.warning(
+                "[video quality] %s: detected CRF %.1f, which is more lossy than the "
+                "recommended maximum CRF %d; validation will continue.",
+                video_label,
+                info.crf,
+                VIDEO_CRF,
+            )
         if not (info.width >= MIN_IMAGE_SIZE and info.height >= MIN_IMAGE_SIZE):
             raise EpisodeValidationError(
                 f"Video too small for camera {cam}: {info.width}x{info.height} "

--- a/oopsie_data_tools/utils/validation/validation_utils.py
+++ b/oopsie_data_tools/utils/validation/validation_utils.py
@@ -18,6 +18,7 @@ from oopsie_data_tools.utils.validation.episode_validator import validate_episod
 from oopsie_data_tools.utils.validation.errors import EpisodeValidationError
 
 logger = logging.getLogger(__name__)
+VALIDATION_LOGGER_NAME = "oopsie_data_tools.utils.validation"
 
 
 def validate_h5_file(
@@ -43,7 +44,10 @@ def validate_h5_file(
             ``AssertionError``, so ``except AssertionError`` still catches it.
     """
     if log_path is not None:
-        setup_logger(__name__, log_path)
+        # Attach at the shared validation namespace so sibling modules such as
+        # episode_loader and episode_validator are captured too. A handler on this module's
+        # logger only sees its own records; logging propagation never travels sideways.
+        setup_logger(VALIDATION_LOGGER_NAME, log_path)
     data = load_episode_from_h5(h5_path, allowed_root=allowed_root)
     validate_episode(data, strict_annotation_check=strict_annotation_check)
     return True
@@ -98,7 +102,7 @@ def validate_session_dir(session_dir: str, strict_annotation_check: bool = False
         0 if all files passed, 1 if any failed or the directory is invalid.
     """
     if log_path is not None:
-        setup_logger(__name__, log_path)
+        setup_logger(VALIDATION_LOGGER_NAME, log_path)
 
     session_path = os.path.abspath(os.path.normpath(session_dir))
     if not os.path.isdir(session_path):

--- a/oopsie_data_tools/utils/video_encoding.py
+++ b/oopsie_data_tools/utils/video_encoding.py
@@ -1,0 +1,3 @@
+"""Shared video-encoding policy for recording and validation."""
+
+VIDEO_CRF = 19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oopsie-data-tools"
-version = "1.0.0"
+version = "1.0.1"
 description = "Collect, annotate, validate and upload robotic manipulation rollout data."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Implemented the shared CRF advisory check for both EpisodeRecorder and converted videos.

Expected hehavior:
- CRF ≤ 19: accepted silently.
- CRF > 19: yellow warning; validation still passes.
- CRF unavailable or unreliable: yellow warning; validation still passes.

Speed of validation before/after the change:
- Validation without CRF scan: 2.79 ms/video
- Validation with CRF scan: 2.87 ms/video

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Advisory-only validation changes and logging UX; no new hard failures or auth/data-path changes.
> 
> **Overview**
> Introduces a shared **`VIDEO_CRF` (19)** policy in `video_encoding.py` and wires it through recording, fixtures, and validation so encoding and checks stay aligned.
> 
> Episode validation now **scans MP4s for embedded x264 CRF** (`detect_x264_crf`) when loading videos; `VideoInfo` carries optional `path` and `crf`. During semantic checks, **CRF above the target or unknown CRF emits a warning only**—validation still passes. The recorder passes the expected CRF into pre-save `VideoInfo` and drops its local constant.
> 
> **CLI logging** is centralized: warnings (including the PyPI update notice) go through a formatter that styles **WARNING** in yellow instead of ad hoc `click.secho` on stderr. Validation log files attach at the shared **`oopsie_data_tools.utils.validation`** logger so CRF advisories from `episode_validator` are captured when `log_path` is set.
> 
> Test fixtures encode at CRF 19; new tests cover CRF detection, advisory behavior, log output, and `_CliFormatter`. Package version **1.0.0 → 1.0.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6ec1e8b7a2ab8b717af3196247dc612a1084f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->